### PR TITLE
fix infinite loop when feeding the onChange(value) back to setProps({value})

### DIFF
--- a/src/ace.jsx
+++ b/src/ace.jsx
@@ -86,7 +86,9 @@ module.exports = React.createClass({
     this.editor.getSession().setMode('ace/mode/'+nextProps.mode);
     this.editor.setTheme('ace/theme/'+nextProps.theme);
     this.editor.setFontSize(nextProps.fontSize);
-    this.editor.setValue(nextProps.value);
+    if (this.editor.getValue() !== nextProps.value) {
+      this.editor.setValue(nextProps.value);
+    }
     this.editor.renderer.setShowGutter(nextProps.showGutter);
     if (nextProps.onLoad) {
       nextProps.onLoad();


### PR DESCRIPTION
Hi, thanks for the component!

I have an issue: if i do this:
```javascript
var editor = React.render(React.createElement(AceEditor, {
  value: source,
  onChange: createAction,
}), document.body);

function createAction(newSource) {
  source = newSource;
  if (editor) editor.setProps({value: source});
}
```
i get an infinite loop because after the component.setProps({value}) the ace.setValue(value) will be called and this triggers the "change" event even though the ace.getValue() already equal to the new value.

This pull request fixes that by checking the ace.getValue() before refreshing the ace editor.