### PR TITLE
Give access to Ace editor object in onLoad.

### DIFF
--- a/example/example.jsx
+++ b/example/example.jsx
@@ -1,7 +1,7 @@
 var React = require('react');
 var AceEditor  = require('../src/ace.jsx');
 
-function onLoad() {
+function onLoad(editor) {
   console.log('i\'ve loaded');
 }
 
@@ -23,7 +23,7 @@ React.render(
 
 
 
-var defaultValue = "function onLoad() { \n  console.log(\"i've loaded\");\n}";
+var defaultValue = "function onLoad(editor) { \n  console.log(\"i've loaded\");\n}";
 //render a second 
 React.render(
   <AceEditor 

--- a/src/ace.jsx
+++ b/src/ace.jsx
@@ -90,7 +90,7 @@ module.exports = React.createClass({
     this.editor.setShowPrintMargin(this.props.setShowPrintMargin);
 
     if (this.props.onLoad) {
-      this.props.onLoad();
+      this.props.onLoad(this.editor);
     }
   },
 

--- a/src/ace.jsx
+++ b/src/ace.jsx
@@ -108,7 +108,7 @@ module.exports = React.createClass({
     }
     this.editor.renderer.setShowGutter(nextProps.showGutter);
     if (nextProps.onLoad) {
-      nextProps.onLoad();
+      nextProps.onLoad(this.editor);
     }
   },
 


### PR DESCRIPTION
In order to use parts of the Ace editor API that aren't yet supported, it would be great to have access to `this.editor` outside of the React element.

One easy way of doing this is to pass editor into the onLoad function:

```javascript
if (this.props.onLoad) {
  this.props.onLoad(this.editor);
}
```

Examples of Ace features I need to use are:

```javascript
session = editor.getSession();
session.setTabSize(2);
session.setUseSoftTabs(true);
session.setUseWrapMode(true);

// ...
editor.scrollToRow(0);
editor.selection.clearSelection();
editor.focus();
```