### PR TITLE
set cursor to end of editor text

### DIFF
--- a/src/ace.jsx
+++ b/src/ace.jsx
@@ -52,7 +52,7 @@ module.exports = React.createClass({
     this.editor.setTheme('ace/theme/'+this.props.theme);
     this.editor.setFontSize(this.props.fontSize);
     this.editor.on('change', this.onChange);
-    this.editor.setValue(this.props.value);
+    this.editor.setValue(this.props.value, 1);
     this.editor.renderer.setShowGutter(this.props.showGutter);
     this.editor.setOption('maxLines', this.props.maxLines);
     this.editor.setOption('readOnly', this.props.readOnly);
@@ -74,7 +74,7 @@ module.exports = React.createClass({
     this.editor.setOption('highlightActiveLine', nextProps.highlightActiveLine);
     this.editor.setShowPrintMargin(nextProps.setShowPrintMargin);
     if (this.editor.getValue() !== nextProps.value) {
-      this.editor.setValue(nextProps.value);
+      this.editor.setValue(nextProps.value, 1);
     }
     this.editor.renderer.setShowGutter(nextProps.showGutter);
     if (nextProps.onLoad) {


### PR DESCRIPTION
This resolves an issue where text is highlighted whenever the `value` prop is changed.