### PR TITLE
move modules to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,13 +12,15 @@
   "author": "James Hrisho",
   "license": "MIT",
   "devDependencies": {
-    "browserify": "^6.3.3",
+    "browserify": "^9.0.8",
     "gulp": "^3.8.10",
     "gulp-jshint": "^1.9.0",
     "gulp-react": "^2.0.0",
     "gulp-streamify": "0.0.5",
     "gulp-uglify": "^1.2.0",
     "jest": "^0.1.37",
+    "jsx-loader": "^0.12.2",
+    "reactify": "^1.1.0",
     "vinyl-source-stream": "^1.0.0"
   },
   "keywords": [
@@ -36,11 +38,7 @@
     ]
   },
   "dependencies": {
-    "brace": "^0.5.1",
-    "browserify": "^9.0.8",
-    "jsx-loader": "^0.12.2",
-    "lodash": "^2.4.1",
-    "reactify": "^1.1.0"
+    "brace": "^0.5.1"
   },
   "peerDependencies": {
     "react": ">=0.11.2 <1.0.0"


### PR DESCRIPTION
modules which don't use in the source should be placed in `devDependencies` field