### PR TITLE
move onChange to tail to avoid Infinite loop

### DIFF
--- a/src/ace.jsx
+++ b/src/ace.jsx
@@ -59,13 +59,13 @@ module.exports = React.createClass({
     this.editor.getSession().setMode('ace/mode/'+this.props.mode);
     this.editor.setTheme('ace/theme/'+this.props.theme);
     this.editor.setFontSize(this.props.fontSize);
-    this.editor.on('change', this.onChange);
     this.editor.setValue(this.props.value, this.props.cursorStart);
     this.editor.renderer.setShowGutter(this.props.showGutter);
     this.editor.setOption('maxLines', this.props.maxLines);
     this.editor.setOption('readOnly', this.props.readOnly);
     this.editor.setOption('highlightActiveLine', this.props.highlightActiveLine);
     this.editor.setShowPrintMargin(this.props.setShowPrintMargin);
+    this.editor.on('change', this.onChange);
 
     if (this.props.onLoad) {
       this.props.onLoad(this.editor);


### PR DESCRIPTION
In some flux architecture, if it listens to `change` event before initialize, it's easy to cause a Infinite loop.

(Change) => (Set Value) => (Change) => (Set Value) => ....

So, listen to change event after initialize will much better.