### PR TITLE
replace Object.getOwnPropertyNames with Object.keys 

### DIFF
--- a/src/ace.jsx
+++ b/src/ace.jsx
@@ -51,9 +51,9 @@ module.exports = React.createClass({
   componentDidMount: function() {
     this.editor = ace.edit(this.props.name);
 
-    var editorProps = Object.getOwnPropertyNames(this.props.editorProps)
+    var editorProps = Object.keys(this.props.editorProps);
     for (var i = 0; i < editorProps.length; i++) {
-      this.editor[editorProps[i]] = this.props.editorProps[editorProps[i]]
+      this.editor[editorProps[i]] = this.props.editorProps[editorProps[i]];
     }
 
     this.editor.getSession().setMode('ace/mode/'+this.props.mode);


### PR DESCRIPTION
better to use enumerable own properties

see as reference: http://stackoverflow.com/questions/22658488/object-getownpropertynames-vs-object-keys 