### PR TITLE
Add the possibility to modify ace behaviour before load.

### DIFF
--- a/src/ace.jsx
+++ b/src/ace.jsx
@@ -59,6 +59,9 @@ module.exports = React.createClass({
   },
   componentDidMount: function() {
     this.editor = ace.edit(this.props.name);
+    if (this.props.onBeforeLoad) {
+      this.props.onBeforeLoad(ace);
+    }
 
     var editorProps = Object.keys(this.props.editorProps);
     for (var i = 0; i < editorProps.length; i++) {


### PR DESCRIPTION
In meteor, it is often required to change the paths from where the modules, themes and others are loaded. For this, we need access to the “ace” object:

Example:

```
  onLoad(ace: AceAjax.Ace, editor: AceAjax.Editor) {
    var acePath = "/ace";
    ace.config.set("modePath", acePath);
    ace.config.set("themePath", acePath);
    ace.config.set("workerPath", acePath);
}
```

Having this callback would be really helpful!