### PR TITLE
Add support to react 0.14.0.rc

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "brace": "^0.5.1"
   },
   "peerDependencies": {
-    "react": ">=0.11.2 <1.0.0"
+    "react": ">=0.11.2 <1.0.0 || ^0.14.0-rc"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
The current peer dependencies does not include support for React 0.14.0.rc1.
This approach seems like to allow using the current react-ace version with react 0.14.0.rc1.

I think another approach could be `"react": ">=0.11.2"`.