### PR TITLE
Allow devs to set an initial value without triggering a change event

### DIFF
--- a/src/ace.jsx
+++ b/src/ace.jsx
@@ -68,8 +68,6 @@ module.exports = React.createClass({
     this.editor.getSession().setMode('ace/mode/' + this.props.mode);
     this.editor.setTheme('ace/theme/' + this.props.theme);
     this.editor.setFontSize(this.props.fontSize);
-    this.editor.on('change', this.onChange);
-    this.editor.on('paste', this.onPaste);
     this.editor.setValue(this.props.value, this.props.cursorStart);
     this.editor.renderer.setShowGutter(this.props.showGutter);
     this.editor.setOption('maxLines', this.props.maxLines);
@@ -77,6 +75,7 @@ module.exports = React.createClass({
     this.editor.setOption('highlightActiveLine', this.props.highlightActiveLine);
     this.editor.setShowPrintMargin(this.props.setShowPrintMargin);
     this.editor.on('change', this.onChange);
+    this.editor.on('paste', this.onPaste);
 
     if (this.props.onLoad) {
       this.props.onLoad(this.editor);


### PR DESCRIPTION
The onChange handler was being applied twice, once before the initial editor.setValue() method was called. Besides removing the duplicated code, this helps because an automatic change event was fired whenever an initial value was set. 

I feel this is a better setup because if the user wants an initial change event, they can just fire one manually.