### PR TITLE
Fix setValue onChange infinite loop

### DIFF
--- a/src/ace.jsx
+++ b/src/ace.jsx
@@ -48,7 +48,7 @@ module.exports = React.createClass({
   },
   onChange: function() {
     var value = this.editor.getValue();
-    if (this.props.onChange) {
+    if (this.props.onChange && !this.silent) {
       this.props.onChange(value);
     }
   },
@@ -99,7 +99,10 @@ module.exports = React.createClass({
     this.editor.setOption('highlightActiveLine', nextProps.highlightActiveLine);
     this.editor.setShowPrintMargin(nextProps.setShowPrintMargin);
     if (this.editor.getValue() !== nextProps.value) {
+      // editor.setValue is a synchronous function call, change event is emitted before setValue return.
+      this.silent = true;
       this.editor.setValue(nextProps.value, nextProps.cursorStart);
+      this.silent = false;
     }
     this.editor.renderer.setShowGutter(nextProps.showGutter);
     if (nextProps.onLoad) {


### PR DESCRIPTION
#38 && #10  target on the same problem. But this problem still exist.

In native input && textarea component, the onChange callback will not be called when the value props change.

But in AceEditor, onChange will be called.

see https://jsfiddle.net/crysislinux/402othpj/1/

This behavior will cause problem in some Flux implementation (e.g Alt)

Alt separate each dispatching, a second dispatching cannot be triggered if the first one has not finished. 

But now,

value changed --> dispatch --> value prop changed --> setValue called --> change event triggered --> onChange called --> trigger alt action to save value in alt store --> another dispatch --> boom

In short, the setValue call should not lead a onChange call.