### PR TITLE
Add prop for keyboardHandler

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,11 +71,12 @@ Available Props
 |onFocus| function that trigger by editor `focus` event|
 |onBlur| function that trigger by editor `blur` event|
 |editorProps| Object of properties to apply directly to the Ace editor instance|
+|keyboardHandler| String corresponding to the keybinding mode to set (such as vim)|
 
 
-## Modes and Themes
+## Modes, Themes, and Keyboard Handlers
 
-All modes and themes should be required through ```brace``` directly.  Browserify will grab these modes / themes through ```brace``` and will be available at run time.  See the example above.  This prevents bloating the compiled javascript with extra modes and themes for your application.
+All modes, themes, and keyboard handlers should be required through ```brace``` directly.  Browserify will grab these modes / themes / keyboard handlers through ```brace``` and will be available at run time.  See the example above.  This prevents bloating the compiled javascript with extra modes and themes for your application.
 
 ### Example Modes
 
@@ -107,3 +108,8 @@ All modes and themes should be required through ```brace``` directly.  Browserif
 * solarized dark
 * solarized light
 * terminal
+
+### Example Keyboard Handlers
+
+* vim
+* emacs

--- a/src/ace.jsx
+++ b/src/ace.jsx
@@ -28,7 +28,8 @@ module.exports = React.createClass({
     tabSize: React.PropTypes.number,
     showPrintMargin: React.PropTypes.bool,
     cursorStart: React.PropTypes.number,
-    editorProps: React.PropTypes.object
+    editorProps: React.PropTypes.object,
+    keyboardHandler: React.PropTypes.string
   },
   getDefaultProps: function() {
     return {
@@ -105,6 +106,9 @@ module.exports = React.createClass({
     this.editor.on('paste', this.onPaste);
     this.editor.on('change', this.onChange);
     
+    if (this.props.keyboardHandler) {
+      this.editor.setKeyboardHandler('ace/keyboard/' + this.props.keyboardHandler);
+    }
 
     if (this.props.onLoad) {
       this.props.onLoad(this.editor);


### PR DESCRIPTION
This adds the ability to specify a keyboardHandler on the React component (such as vim or emacs).

`setKeyboardHandler` will only execute if the prop is set - this is because we cannot hardcode the default value as it is platform specific (osx/windows/etc).