### PR TITLE
remove call ace.edit on every time receive props

### DIFF
--- a/src/ace.jsx
+++ b/src/ace.jsx
@@ -5,7 +5,6 @@ module.exports = React.createClass({
   displayName: 'ReactAce',
 
   propTypes: {
-
     mode: React.PropTypes.string,
     theme: React.PropTypes.string,
     name: React.PropTypes.string,
@@ -120,7 +119,6 @@ module.exports = React.createClass({
   },
 
   componentWillReceiveProps: function(nextProps) {
-    this.editor = ace.edit(nextProps.name);
     this.editor.getSession().setMode('ace/mode/' + nextProps.mode);
     this.editor.setTheme('ace/theme/' + nextProps.theme);
     this.editor.setFontSize(nextProps.fontSize);


### PR DESCRIPTION
I think finally we should have a random id for component lifecycle, and avoid let people assign name. If you have two editors have same `name` props, it won't works.