### PR TITLE
update brace to 0.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "brace"
   ],
   "dependencies": {
-    "brace": "^0.5.1"
+    "brace": "^0.7.0"
   },
   "peerDependencies": {
     "react": ">=0.11.2 <1.0.0 || ^0.14.0-rc"


### PR DESCRIPTION
brace has several updates in it, including bringing ace to version 1.2.2.  This just updates the package.json reference to brace to the latest version.