### PR TITLE
componentWillUnmount: destroy editor

### DIFF
--- a/src/ace.jsx
+++ b/src/ace.jsx
@@ -119,6 +119,7 @@ export default class ReactAce extends Component {
   }
 
   componentWillUnmount() {
+    this.editor.destroy();
     this.editor = null;
   }
 


### PR DESCRIPTION
The `editor` leaks event listeners if you just `null` it: https://github.com/ajaxorg/ace/issues/2085. Calling `destroy()` triggers the full cleanup, so let's do that. 