### PR TITLE
Initialize ace editor with a dom node reference instead of an element id

### DIFF
--- a/example/index.js
+++ b/example/index.js
@@ -24,7 +24,6 @@ render(
   <AceEditor
     mode="java"
     theme="github"
-    name="blah1"
     height="6em"
     onChange={onChange}
   />,
@@ -41,7 +40,6 @@ render(
   <AceEditor
     mode="javascript"
     theme="monokai"
-    name="blah2"
     onLoad={onLoad}
     fontSize={14}
     height="6em"

--- a/src/ace.jsx
+++ b/src/ace.jsx
@@ -17,9 +17,15 @@ export default class ReactAce extends Component {
   }
 
   componentDidMount() {
+    const { onBeforeLoad } = this.props;
+
+    if (onBeforeLoad) {
+      onBeforeLoad(ace);
+    }
+  }
+
+  initEditor(element) {
     const {
-      name,
-      onBeforeLoad,
       mode,
       theme,
       fontSize,
@@ -37,11 +43,7 @@ export default class ReactAce extends Component {
       onLoad,
     } = this.props;
 
-    this.editor = ace.edit(name);
-
-    if (onBeforeLoad) {
-      onBeforeLoad(ace);
-    }
+    this.editor = ace.edit(element);
 
     const editorProps = Object.keys(this.props.editorProps);
     for (let i = 0; i < editorProps.length; i++) {
@@ -161,6 +163,7 @@ export default class ReactAce extends Component {
         id={name}
         className={className}
         style={divStyle}
+        ref={ (element) => this.initEditor(element) }
       >
       </div>
     );


### PR DESCRIPTION
This removes the need to give each instance of react-ace a unique id
while also eliminates issues with not finding the ace div element in
certain use cases such as inside iframes.