### PR TITLE
Support for EditSession changeAnnotation event

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Looking for a way to set it up using webpack? Checkout `example` directory for a
 |value | String value you want to populate in the code highlighter|
 |onLoad| Function onLoad|
 |onBeforeLoad| function that trigger before editor setup|
+|onAnnotationChange| function that occurs on annotation change it has 1 argument value.|
 |onChange| function that occurs on document change it has 1 argument value. see the example above|
 |onCopy| function that trigger by editor `copy` event, and pass text as argument|
 |onPaste| function that trigger by editor `paste` event, and pass text as argument|

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "clean": "rimraf lib dist",
     "lint": "node_modules/.bin/eslint src/ace.jsx",
-    "build:lib": "babel src --out-dir lib",
+    "build:lib": "babel --presets react --out-dir lib/ src/",
     "build:umd": "webpack src/ace.jsx dist/react-ace.js --config webpack.config.development.js",
     "build:umd:min": "webpack src/ace.jsx dist/react-ace.min.js --config webpack.config.production.js",
     "build:example": "cd example && npm install",
@@ -21,9 +21,8 @@
   "author": "James Hrisho",
   "license": "MIT",
   "devDependencies": {
-    "babel": "^5.8.23",
-    "babel-core": "^5.8.25",
-    "babel-loader": "^5.3.2",
+    "babel-cli": "6.6.0",
+    "babel-preset-react": "6.5.0",
     "eslint": "^1.10.3",
     "eslint-config-airbnb": "^2.1.1",
     "eslint-plugin-react": "^3.13.1",

--- a/src/ace.jsx
+++ b/src/ace.jsx
@@ -16,10 +16,11 @@ export default class ReactAce extends Component {
   constructor(props) {
     super(props);
     [
-      'onChange',
-      'onFocus',
+      'onAnnotationChange',
       'onBlur',
+      'onChange',
       'onCopy',
+      'onFocus',
       'onPaste',
     ]
     .forEach(method => {
@@ -56,6 +57,7 @@ export default class ReactAce extends Component {
     }
 
     this.editor.getSession().setMode(`ace/mode/${mode}`);
+    this.editor.getSession().on('changeAnnotation', this.onAnnotationChange);
     this.editor.setTheme(`ace/theme/${theme}`);
     this.editor.setFontSize(fontSize);
     this.editor.setValue(value, cursorStart);
@@ -129,6 +131,13 @@ export default class ReactAce extends Component {
     this.editor = null;
   }
 
+  onAnnotationChange() {
+    if (this.props.onAnnotationChange) {
+      const annotations = this.editor.getSession().getAnnotations();
+      this.props.onAnnotationChange(annotations);
+    }
+  }
+
   onChange() {
     if (this.props.onChange && !this.silent) {
       const value = this.editor.getValue();
@@ -183,11 +192,12 @@ ReactAce.propTypes = {
   width: PropTypes.string,
   fontSize: PropTypes.number,
   showGutter: PropTypes.bool,
+  onAnnotationChange: PropTypes.func,
+  onBlur: PropTypes.func,
   onChange: PropTypes.func,
   onCopy: PropTypes.func,
-  onPaste: PropTypes.func,
   onFocus: PropTypes.func,
-  onBlur: PropTypes.func,
+  onPaste: PropTypes.func,
   value: PropTypes.string,
   onLoad: PropTypes.func,
   onBeforeLoad: PropTypes.func,
@@ -221,6 +231,7 @@ ReactAce.defaultProps = {
   value: '',
   fontSize: 12,
   showGutter: true,
+  onAnnotationChange: null,
   onChange: null,
   onPaste: null,
   onLoad: null,


### PR DESCRIPTION
Adds an onAnnotationChange event. This is useful for displaying custom warnings/errors when gutter is not used.

Docs from ace editor: https://ace.c9.io/#nav=api&api=edit_session
