### PR TITLE
Revert "Initialize ace editor with a dom node reference instead of an element id"

### DIFF
--- a/example/index.js
+++ b/example/index.js
@@ -25,6 +25,7 @@ render(
   <AceEditor
     mode="java"
     theme="github"
+    name="blah1"
     height="6em"
     onChange={onChange}
   />,
@@ -41,6 +42,7 @@ render(
   <AceEditor
     mode="javascript"
     theme="monokai"
+    name="blah2"
     onLoad={onLoad}
     fontSize={14}
     height="6em"

--- a/src/ace.jsx
+++ b/src/ace.jsx
@@ -30,15 +30,9 @@ export default class ReactAce extends Component {
   }
 
   componentDidMount() {
-    const { onBeforeLoad } = this.props;
-
-    if (onBeforeLoad) {
-      onBeforeLoad(ace);
-    }
-  }
-
-  initEditor(element) {
     const {
+      name,
+      onBeforeLoad,
       mode,
       theme,
       fontSize,
@@ -52,7 +46,11 @@ export default class ReactAce extends Component {
       commands,
     } = this.props;
 
-    this.editor = ace.edit(element);
+    this.editor = ace.edit(name);
+
+    if (onBeforeLoad) {
+      onBeforeLoad(ace);
+    }
 
     const editorProps = Object.keys(this.props.editorProps);
     for (let i = 0; i < editorProps.length; i++) {
@@ -183,7 +181,6 @@ export default class ReactAce extends Component {
         id={name}
         className={className}
         style={divStyle}
-        ref={ (element) => this.initEditor(element) }
       >
       </div>
     );


### PR DESCRIPTION
Reverts securingsincity/react-ace#93