### PR TITLE
Check if this.editor is defined inside componentWillReceiveProps

### DIFF
--- a/src/ace.jsx
+++ b/src/ace.jsx
@@ -122,7 +122,7 @@ export default class ReactAce extends Component {
     if (!isEqual(nextProps.setOptions, oldProps.setOptions)) {
       this.handleOptions(nextProps);
     }
-    if (this.editor.getValue() !== nextProps.value) {
+    if (this.editor && this.editor.getValue() !== nextProps.value) {
       // editor.setValue is a synchronous function call, change event is emitted before setValue return.
       this.silent = true;
       this.editor.setValue(nextProps.value, nextProps.cursorStart);


### PR DESCRIPTION
I am experiencing an issue where ``componentWillReceiveProps`` is called before ``componentDidMount``, because of this ``this.editor`` is undefined and the call to ``getValue`` results in a ``TypeError``. According to the React documentation on the lifecycle of components ``componentWillReceiveProps`` is not called on the initial render, thus I do not understand why this issue appears (see #106). This PR is a simple fix to avoid the explained issue, however I am uncertain whether the issue occurs because of some wrong initialization on my end, is anyone else also experiencing this issue? The issue only happens when the component has already been mounted before and is now remounted (i.e. you navigated away from the page and revisit it using react-router).

Edit:

I have investigated the issue and it seems React does not guarantee that ``componentWillReceiveProps`` is called only after ``componentDidMount`` (see this [stackoverflow answer](http://stackoverflow.com/a/37415405/2106835)).