### PR TITLE
Preserve cursor position on `setValue`

### DIFF
--- a/src/ace.jsx
+++ b/src/ace.jsx
@@ -127,7 +127,9 @@ export default class ReactAce extends Component {
     if (this.editor && this.editor.getValue() !== nextProps.value) {
       // editor.setValue is a synchronous function call, change event is emitted before setValue return.
       this.silent = true;
+      const pos = this.editor.session.selection.toJSON();
       this.editor.setValue(nextProps.value, nextProps.cursorStart);
+      this.editor.session.selection.fromJSON(pos);
       this.silent = false;
     }
   }


### PR DESCRIPTION
fixes #120, and other redux related issues,

problem: everytime `dispatch` is called in `onChage` that triggers react-ace's `componentWillReceiveProps` which in turn calls `setValue` on underlying editor, which causes it to loose cursor position

this pull request fixes it