### PR TITLE
Add markers and annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ Looking for a way to set it up using webpack? Checkout `example` directory for a
 |setOptions| Object of [options](https://github.com/ajaxorg/ace/wiki/Configuring-Ace) to apply directly to the Ace editor instance|
 |keyboardHandler| String corresponding to the keybinding mode to set (such as vim)|
 |commands| Array of new commands to add to the editor
+|annotations| Array of annotations to show in the editor i.e. `[{ row: 0, column: 2, type: 'error', text: 'Some error.'}]`, displayed in the gutter|
+|markers| Array of [markers](https://ace.c9.io/api/edit_session.html#EditSession.addMarker) to show in the editor, i.e. `[{ startRow: 0, startCol: 2, endRow: 1, endCol: 20, className: 'error-marker', type: 'background' }]`|
 
 
 ## Modes, Themes, and Keyboard Handlers

--- a/src/ace.jsx
+++ b/src/ace.jsx
@@ -45,6 +45,7 @@ export default class ReactAce extends Component {
       keyboardHandler,
       onLoad,
       commands,
+      annotations,
     } = this.props;
 
     this.editor = ace.edit(name);
@@ -72,6 +73,7 @@ export default class ReactAce extends Component {
     this.editor.on('change', this.onChange);
     this.editor.session.on('changeScrollTop', this.onScroll);
     this.handleOptions(this.props);
+    this.editor.getSession().setAnnotations(annotations || []);
 
     for (let i = 0; i < editorOptions.length; i++) {
       const option = editorOptions[i];
@@ -123,6 +125,9 @@ export default class ReactAce extends Component {
     }
     if (!isEqual(nextProps.setOptions, oldProps.setOptions)) {
       this.handleOptions(nextProps);
+    }
+    if (!isEqual(nextProps.annotations, oldProps.annotations)) {
+      this.editor.getSession().setAnnotations(nextProps.annotations || []);
     }
     if (this.editor && this.editor.getValue() !== nextProps.value) {
       // editor.setValue is a synchronous function call, change event is emitted before setValue return.
@@ -222,6 +227,7 @@ ReactAce.propTypes = {
   cursorStart: PropTypes.number,
   editorProps: PropTypes.object,
   setOptions: PropTypes.object,
+  annotations: PropTypes.array,
   keyboardHandler: PropTypes.string,
   wrapEnabled: PropTypes.bool,
   enableBasicAutocompletion: PropTypes.oneOfType([


### PR DESCRIPTION
This adds two new props to set markers and annotations, which both use plain objects and are mapped to what Ace needs (i.e. `Range`s for markers).

Small demonstration (the icon in the gutter also has a tooltip):
![image](https://cloud.githubusercontent.com/assets/5544859/16451025/bd13cac0-3e00-11e6-87fb-5d9f3db51fd3.png)

```jsx
<ReactAce
  uniqueId="editor"
  value="(test "
  markers={[{
    className: 'error-marker',
    startRow: 0,
    startCol: 6,
    endRow: 0,
    endCol: 7
  }]}
  annotations={[{
    column: 6,
    row: 0,
    text: 'Some wild demo error.',
    type: 'error'
  }]}
  editorProps={{ $useWorker: false }}
/>
```

The worker needs to be disabled so that Ace doesn't try to add other markers/annotations by checking the syntax itself.