### PR TITLE
Avoid passing unknown options to Ace

### DIFF
--- a/src/ace.jsx
+++ b/src/ace.jsx
@@ -73,9 +73,13 @@ export default class ReactAce extends Component {
     this.editor.session.on('changeScrollTop', this.onScroll);
     this.handleOptions(this.props);
 
+    // get a list of possible options to avoid 'misspelled option errors'
+    const availableOptions = this.editor.$options;
     for (let i = 0; i < editorOptions.length; i++) {
       const option = editorOptions[i];
-      this.editor.setOption(option, this.props[option]);
+      if (availableOptions.hasOwnProperty(option)) {
+        this.editor.setOption(option, this.props[option]);
+      }
     }
 
     if (Array.isArray(commands)) {


### PR DESCRIPTION
This is done by making sure `editor` has the property in the `$options` dictionary. If not the property is silenced.

Fixes #95 
Fixes #111 