### PR TITLE
Delete babel dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
   "author": "James Hrisho",
   "license": "MIT",
   "devDependencies": {
-    "babel": "^6.5.2",
     "babel-cli": "^6.6.5",
     "babel-core": "^6.7.5",
     "babel-loader": "^6.2.4",


### PR DESCRIPTION
This is a friendly FYI that, while its presence is harmless, you should be able to dispense with this dep; `babel@6` is just a vestige that doesn't really do anything.