### PR TITLE
Allow users to override styles

### DIFF
--- a/example/.babelrc
+++ b/example/.babelrc
@@ -2,7 +2,7 @@
   "presets": ["es2015", "react"],
   "env": {
       "development": {
-        "plugins": [["react-transform", {
+        "plugins": ["transform-object-rest-spread", ["react-transform", {
           "transforms": [{
             "transform": "react-transform-hmr",
             "imports": ["react"],

--- a/example/package.json
+++ b/example/package.json
@@ -24,6 +24,7 @@
     "babel-preset-es2015": "^6.6.0",
     "babel-preset-react": "^6.5.0",
     "babel-plugin-react-transform": "^2.0.2",
+    "babel-plugin-transform-object-rest-spread": "^6.8.0",
     "express": "^4.13.4",
     "node-libs-browser": "^1.0.0",
     "react-transform-hmr": "^1.0.4",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,13 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "babel": {
-    "presets": ["es2015", "react"]
+    "presets": [
+      "es2015",
+      "react"
+    ],
+    "plugins": [
+      "transform-object-rest-spread"
+    ]
   },
   "author": "James Hrisho",
   "license": "MIT",
@@ -28,6 +34,7 @@
     "babel-cli": "^6.6.5",
     "babel-core": "^6.7.5",
     "babel-loader": "^6.2.4",
+    "babel-plugin-transform-object-rest-spread": "^6.8.0",
     "babel-preset-es2015": "^6.6.0",
     "babel-preset-react": "^6.5.0",
     "eslint": "^1.10.3",

--- a/src/ace.jsx
+++ b/src/ace.jsx
@@ -238,8 +238,8 @@ export default class ReactAce extends Component {
   }
 
   render() {
-    const { name, width, height } = this.props;
-    const divStyle = { width, height };
+    const { name, width, height, style } = this.props;
+    const divStyle = { width, height, ...style };
     return (
       <div ref="editor"
         id={name}


### PR DESCRIPTION
AceEditor currently has to be wrapped in order to be aligned as it does not accept style overrides.

```
<div style={{ position: 'absolute', display: 'flex', height: '100%', width: '100%' }}>
    <Canvas style={{ flexGrow: 3 }}>
        ...
    </Canvas>
    <div style={{ flexGrow: 2 }}>
        <AceEditor
            mode="javascript"
            theme="monokai"
            editorProps={{$blockScrolling: true}}
            height="100%"
            width="100%"
            value={code}
        />
    </div>
</div>
```

With this PR 

```
<AceEditor
    style={{ flexGrow: 3 }}
    ...
```