### PR TITLE
render by reference to enable delayed dom injection

### DIFF
--- a/src/ace.jsx
+++ b/src/ace.jsx
@@ -53,7 +53,7 @@ export default class ReactAce extends Component {
       markers,
     } = this.props;
 
-    this.editor = ace.edit(name);
+    this.editor = ace.edit(this.refs.editor);
 
     if (onBeforeLoad) {
       onBeforeLoad(ace);


### PR DESCRIPTION
This lets us dynamically create disconnected DOM elements with ace functionality, that get inserted into the document at a later time. 

The specific use case I have is creating an `AceBlock` node type to be inserted into a ProseMirror instance (http://prosemirror.net/)