### PR TITLE
Use prop-type package instead of React.PropType

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "mocha": "^3.1.2",
     "nyc": "^8.3.1",
     "react-addons-test-utils": "^15.3.2",
+    "react-test-renderer": "^15.5.4",
     "rimraf": "^2.5.2",
     "sinon": "^1.17.6",
     "webpack": "^1.12.14"
@@ -61,7 +62,8 @@
   ],
   "dependencies": {
     "brace": "^0.9.1",
-    "lodash.isequal": "^4.1.1"
+    "lodash.isequal": "^4.1.1",
+    "prop-types": "^15.5.8"
   },
   "peerDependencies": {
     "react": "^0.13.0 || ^0.14.0 || ^15.0.1",

--- a/src/ace.jsx
+++ b/src/ace.jsx
@@ -1,5 +1,6 @@
 import ace from 'brace';
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types'
 import isEqual from 'lodash.isequal';
 
 const { Range } = ace.acequire('ace/range');


### PR DESCRIPTION
In 15.5, instead of accessing PropTypes from the main React object,
install the prop-types package and import them from there.

https://facebook.github.io/react/blog/2017/04/07/react-v15.5.0.html#migrating-from-react.proptypes