### PR TITLE
React.Component cannot accept undefined for props or state

### DIFF
--- a/types.d.ts
+++ b/types.d.ts
@@ -164,4 +164,4 @@ export interface AceEditorProps {
     markers?: Array<Marker>
 }
 
-export default class AceEditor extends Component<AceEditorProps, undefined> {}
+export default class AceEditor extends Component<AceEditorProps, {}> {}


### PR DESCRIPTION
Without this change this produces the following error:

(123,13): error TS2605: JSX element type 'AceEditor' is not a constructor function for JSX elements.
  Types of property 'state' are incompatible.
    Type 'undefined' is not assignable to type 'Readonly<{}>'.

# What's in this PR?

## List the changes you made and your reasons for them.

Make sure any changes to code include changes to documentation.

## References

### Fixes #

### Progress on: #