### PR TITLE
Fix Typescript type definition for 'EditorProps'

### DIFF
--- a/types.d.ts
+++ b/types.d.ts
@@ -94,7 +94,7 @@ export interface AceOptions {
 }
 
 export interface EditorProps {
-    $blockScrolling?: number
+    $blockScrolling?: number | boolean
     $blockSelectEnabled?: boolean
     $enableBlockSelect?: boolean
     $enableMultiselect?: boolean


### PR DESCRIPTION
# What's in this PR?
Minor fix for typescript type definitions

## List the changes you made and your reasons for them.
The 'editorProps' property '$blockScrolling' can take number as well as boolean. Type definition set as union of number and boolean to reflect that.

## References
[README.md](https://github.com/securingsincity/react-ace/blob/master/README.md) example shows $blockScrolling property as a boolean

```javascript

// ...
render(
  <AceEditor
    mode="java"
    theme="github"
    onChange={onChange}
    name="UNIQUE_ID_OF_DIV"
    editorProps={{$blockScrolling: true}}
  />,
  document.getElementById('example')
);
```
### Fixes #

### Progress on: 
#211 Typescript Supprt