### PR TITLE
Fix sizing issues

### DIFF
--- a/src/ace.js
+++ b/src/ace.js
@@ -179,9 +179,9 @@ export default class ReactAce extends Component {
   }
 
   componentDidUpdate(prevProps) {
-      if(prevProps.height !== this.props.height || prevProps.width !== this.props.width){
-          this.editor.resize();
-      }
+    if(prevProps.height !== this.props.height || prevProps.width !== this.props.width){
+      this.editor.resize();
+    }
   }
 
   handleScrollMargins(margins = [0, 0, 0, 0]) {

--- a/src/ace.js
+++ b/src/ace.js
@@ -100,6 +100,8 @@ export default class ReactAce extends Component {
     if (onLoad) {
       onLoad(this.editor);
     }
+
+    this.editor.resize();
   }
 
   componentWillReceiveProps(nextProps) {
@@ -174,9 +176,12 @@ export default class ReactAce extends Component {
     if (nextProps.focus && !oldProps.focus) {
       this.editor.focus();
     }
-    if(nextProps.height !== this.props.height || nextProps.width !== this.props.width){
-      this.editor.resize();
-    }
+  }
+
+  componentDidUpdate(prevProps) {
+      if(prevProps.height !== this.props.height || prevProps.width !== this.props.width){
+          this.editor.resize();
+      }
   }
 
   handleScrollMargins(margins = [0, 0, 0, 0]) {


### PR DESCRIPTION
`resize` should be called on `componentDidMount` after the component got initial value for the `height`. Also it should be called every time on `componentDidUpdate` after the editor received the new value for the `height`. 

### Fixes #212 and Fixes #207 