### PR TITLE
chore(package.json): use prepublishOnly

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "preversion": "npm run clean && npm run check",
     "version": "npm run build",
     "postversion": "git push && git push --tags && npm run clean",
-    "prepublish": "npm run clean && npm run build",
+    "prepublishOnly": "npm run clean && npm run build",
     "test": "mocha --compilers js:babel-core/register --require tests/setup.js --recursive tests/**/*.spec.js",
     "coverage": "nyc npm run test",
     "postinstall": "opencollective postinstall"


### PR DESCRIPTION
# What's in this PR?
npm 4 is splitting the prepublish script into two new: prepare and prepublishOnly.  

* prepare will have the same behavior that prepublish has now. Commands in this script will run both before publishing and on npm install.
* prepublishOnly, as seen from its name, will run only before publishing the package.  

Also, prepublish will receive a warning about the changes.

## List the changes you made and your reasons for them.
prepublish ->prepublishOnly

Make sure any changes to code include changes to documentation.

## References

### Fixes #

### Progress on: #