### PR TITLE
chore(package): update to react 16

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "chai": "^4.1.2",
     "coveralls": "^3.0.0",
     "enzyme": "^3.0.0",
-    "enzyme-adapter-react-15": "^1.0.0",
+    "enzyme-adapter-react-16": "^1.0.1",
     "eslint": "4.8.0",
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-jsx-a11y": "^6.0.0",
@@ -53,7 +53,8 @@
     "jsdom": "^11.0.0",
     "mocha": "3.5.3",
     "nyc": "11.2.1",
-    "react-addons-test-utils": "^15.5.1",
+    "react": "^16.0.0",
+    "react-dom": "^16.0.0",
     "react-test-renderer": "^16.0.0",
     "rimraf": "2.6.2",
     "sinon": "4.0.1",
@@ -71,13 +72,11 @@
     "brace": "^0.10.0",
     "lodash.get": "^4.4.2",
     "lodash.isequal": "^4.1.1",
-    "prop-types": "^15.5.8",
-    "react": "^15.6.2",
-    "react-dom": "^15.6.2"
+    "prop-types": "^15.5.8"
   },
   "peerDependencies": {
-    "react": "^0.13.0 || ^0.14.0 || ^15.0.1",
-    "react-dom": "^0.13.0 || ^0.14.0 || ^15.0.1"
+    "react": "^0.13.0 || ^0.14.0 || ^15.0.1 || ^16.0.0",
+    "react-dom": "^0.13.0 || ^0.14.0 || ^15.0.1 || ^16.0.0"
   },
   "nyc": {
     "exclude": [

--- a/tests/src/ace.spec.js
+++ b/tests/src/ace.spec.js
@@ -5,7 +5,7 @@ import ace from 'brace';
 import Enzyme, { mount } from 'enzyme';
 import AceEditor from '../../src/ace.js';
 import brace from 'brace'; // eslint-disable-line no-unused-vars
-import Adapter from 'enzyme-adapter-react-15';
+import Adapter from 'enzyme-adapter-react-16';
 
 Enzyme.configure({ adapter: new Adapter() });
 describe('Ace Component', () => {

--- a/tests/src/split.spec.js
+++ b/tests/src/split.spec.js
@@ -5,7 +5,7 @@ import ace from 'brace';
 import Enzyme, { mount } from 'enzyme';
 import SplitEditor from '../../src/split.js';
 import brace from 'brace'; // eslint-disable-line no-unused-vars
-import Adapter from 'enzyme-adapter-react-15';
+import Adapter from 'enzyme-adapter-react-16';
 
 Enzyme.configure({ adapter: new Adapter() });
 


### PR DESCRIPTION
# What's in this PR?

- remove `react` and `react-dom` from `dependencies` and move them to `devDependencies`
- update `peerDependencies` to allow use React 16

## List the changes you made and your reasons for them.

- update react to 16
- replace `enzyme-adapter-react-15` with `enzyme-adapter-react-16`
- remove `react-addons-test-utils`, we don't need it with `enzyme-adapter-react-16`

## References

Replaces #268
Replaces #269

### Fixes

Fixes #279