### PR TITLE
#285: added the possibility to change key bindings of existing commands.

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -133,6 +133,25 @@ render() {
   </div>;
 }
 ```
+## How do I change key-bindings for an existing command?
+Same syntax as above, where `exec` is given the name of the command to rebind.
+```javascript
+
+render() {
+  return <div>
+    <AceEditor
+      ref="aceEditor"
+      mode="sql"     // Default value since this props must be set.
+      theme="chrome" // Default value since this props must be set.
+      commands={[{   // commands is array of key bindings.
+        name: 'removeline', //name for the key binding.
+        bindKey: {win: 'Ctrl-X', mac: 'Command-X'}, //key combination used for the command.
+        exec: () => 'removeline'  // name of the command to rebind
+      }]}
+    />
+  </div>;
+}
+```
 
 ## How do I add the search box?
 Add the following line

--- a/src/ace.js
+++ b/src/ace.js
@@ -88,7 +88,12 @@ export default class ReactAce extends Component {
 
     if (Array.isArray(commands)) {
       commands.forEach((command) => {
-        this.editor.commands.addCommand(command);
+        if(typeof command.exec == "string") {
+          this.editor.commands.bindKey(command.bindKey, command.exec);
+        }
+        else {
+          this.editor.commands.addCommand(command);
+        }
       });
     }
 

--- a/src/ace.js
+++ b/src/ace.js
@@ -88,7 +88,7 @@ export default class ReactAce extends Component {
 
     if (Array.isArray(commands)) {
       commands.forEach((command) => {
-        if(typeof command.exec == "string") {
+        if(typeof command.exec == 'string') {
           this.editor.commands.bindKey(command.bindKey, command.exec);
         }
         else {

--- a/src/split.js
+++ b/src/split.js
@@ -99,7 +99,7 @@ export default class SplitComponent extends Component {
 
       if (Array.isArray(commands)) {
         commands.forEach((command) => {
-          if(typeof command.exec == "string") {
+          if(typeof command.exec == 'string') {
             editor.commands.bindKey(command.bindKey, command.exec);
           }
           else {

--- a/src/split.js
+++ b/src/split.js
@@ -96,9 +96,15 @@ export default class SplitComponent extends Component {
         }
       }
       this.handleOptions(this.props, editor);
+
       if (Array.isArray(commands)) {
         commands.forEach((command) => {
-          editor.commands.addCommand(command);
+          if(typeof command.exec == "string") {
+            editor.commands.bindKey(command.bindKey, command.exec);
+          }
+          else {
+            editor.commands.addCommand(command);
+          }
         });
       }
 

--- a/tests/src/ace.spec.js
+++ b/tests/src/ace.spec.js
@@ -109,6 +109,21 @@ describe('Ace Component', () => {
       expect(editor.commands.commands.myTestCommand).to.deep.equal(commandsMock[1]);
     });
 
+    it('should change the command binding for the Ace element', () => {
+      const commandsMock = [
+        {
+          bindKey: {win: 'ctrl-d', mac: 'command-d'},
+          name: 'selectMoreAfter',
+          exec: 'selectMoreAfter'
+        }
+      ];
+      const wrapper = mount(<AceEditor commands={commandsMock}/>, mountOptions);
+
+      const editor = wrapper.instance().editor;
+      const expected = [editor.commands.commands.removeline, "selectMoreAfter"]
+      expect(editor.commands.commandKeyBinding['ctrl-d']).to.deep.equal(expected);
+    });
+
     it('should trigger the focus on mount', () => {
       const onFocusCallback = sinon.spy();
       mount(<AceEditor focus={true} onFocus={onFocusCallback}/>, mountOptions);

--- a/tests/src/split.spec.js
+++ b/tests/src/split.spec.js
@@ -103,6 +103,21 @@ describe('Split Component', () => {
       expect(editor.commands.commands.myTestCommand).to.deep.equal(commandsMock[1]);
     });
 
+    it('should change the command binding for the Ace element', () => {
+      const commandsMock = [
+        {
+          bindKey: {win: 'ctrl-d', mac: 'command-d'},
+          name: 'selectMoreAfter',
+          exec: 'selectMoreAfter'
+        }
+      ];
+      const wrapper = mount(<SplitEditor commands={commandsMock}/>, mountOptions);
+
+      const editor = wrapper.instance().splitEditor;
+      const expected = [editor.commands.commands.removeline, "selectMoreAfter"]
+      expect(editor.commands.commandKeyBinding['ctrl-d']).to.deep.equal(expected);
+    });
+
     it('should get the editor from the onLoad callback', () => {
       const loadCallback = sinon.spy();
       const wrapper = mount(<SplitEditor onLoad={loadCallback}/>, mountOptions);


### PR DESCRIPTION
# What's in this PR?
In ace, it is possible to remap a keybinding by using the bindkey method,
it should be possible with react-ace too.
This can now be done by specifying an existing method name for `exec` instead of a function.

## List the changes you made and your reasons for them.
- Implemented the change in both src/ace.js and src/split.js
- Added unit tests for both ace.js and split.js. 
I should mention here that ace seem to use a MultiHashHandler by default, 
and thus the new key-bindings are appended to the existing ones, but the most recently
added has the priority.
- Updated the FAQ.md next to the "How do I add key-bindings?" paragraph

I did not edit the example (even if I tested on it), because the `commands`
props was not used, and so I didn't want to complexify it.

## References
https://github.com/securingsincity/react-ace/issues/285#issuecomment-334810082

### Fixes #

### Progress on: #