### PR TITLE
Add support onCursorChange event

### DIFF
--- a/docs/Ace.md
+++ b/docs/Ace.md
@@ -67,6 +67,7 @@ render(
 |onCopy| | Function | triggered  by editor `copy` event, and passes text as argument|
 |onPaste| | Function | Triggered by editor `paste` event, and passes text as argument|
 |onSelectionChange| | Function | triggered by editor `selectionChange` event, and passes a [Selection](https://ace.c9.io/#nav=api&api=selection) as it's first argument and the event as the second|
+|onCursorChange| | Function | triggered by editor `changeCursor` event, and passes a [Selection](https://ace.c9.io/#nav=api&api=selection) as it's first argument and the event as the second|
 |onFocus| | Function | triggered by editor `focus` event|
 |onBlur| | Function | triggered by editor `blur` event|
 |onInput| | Function | triggered by editor `input` event|

--- a/docs/Split.md
+++ b/docs/Split.md
@@ -65,6 +65,7 @@ render(
 |onCopy| | Function | triggered  by editor `copy` event, and passes text as argument|
 |onPaste| | Function | Triggered by editor `paste` event, and passes text as argument|
 |onSelectionChange| | Function | triggered by editor `selectionChange` event, and passes a [Selection](https://ace.c9.io/#nav=api&api=selection) as it's first argument and the event as the second|
+|onCursorChange| | Function | triggered by editor `changeCursor` event, and passes a [Selection](https://ace.c9.io/#nav=api&api=selection) as it's first argument and the event as the second|
 |onFocus| | Function | triggered by editor `focus` event|
 |onBlur| | Function | triggered by editor `blur` event|
 |onInput| | Function | triggered by editor `input` event|

--- a/example/index.js
+++ b/example/index.js
@@ -68,6 +68,11 @@ class App extends Component {
     console.log('select-change-event', event);
   }
 
+  onCursorChange(newValue, event) {
+    console.log('cursor-change', newValue);
+    console.log('cursor-change-event', event);
+  }
+
   onValidate(annotations) {
     console.log('onValidate', annotations);
   }
@@ -221,6 +226,7 @@ class App extends Component {
           onLoad={this.onLoad}
           onChange={this.onChange}
           onSelectionChange={this.onSelectionChange}
+          onCursorChange={this.onCursorChange}
           onValidate={this.onValidate}
           value={this.state.value}
           fontSize={this.state.fontSize}

--- a/example/split.js
+++ b/example/split.js
@@ -70,6 +70,12 @@ class App extends Component {
     console.log('select-change', newValue);
     console.log('select-change-event', event);
   }
+  
+  onCursorChange(newValue, event) {
+    console.log('cursor-change', newValue);
+    console.log('cursor-change-event', event);
+  }
+
   setTheme(e) {
     this.setState({
       theme: e.target.value

--- a/src/ace.js
+++ b/src/ace.js
@@ -63,6 +63,7 @@ export default class ReactAce extends Component {
     this.editor.on('change', this.onChange);
     this.editor.on('input', this.onInput);
     this.editor.getSession().selection.on('changeSelection', this.onSelectionChange);
+    this.editor.getSession().selection.on('changeCursor', this.onCursorChange);
     if (onValidate) {
       this.editor.getSession().on('changeAnnotation', () => {
         const annotations = this.editor.getSession().getAnnotations();
@@ -219,6 +220,12 @@ export default class ReactAce extends Component {
       this.props.onSelectionChange(value, event);
     }
   }
+  onCursorChange(event) {
+    if(this.props.onCursorChange) {
+      const value = this.editor.getSelection();
+      this.props.onCursorChange(value, event)
+    }
+  }
   onInput(event) {
     if (this.props.onInput) {
       this.props.onInput(event)
@@ -324,6 +331,7 @@ ReactAce.propTypes = {
   defaultValue: PropTypes.string,
   onLoad: PropTypes.func,
   onSelectionChange: PropTypes.func,
+  onCursorChange: PropTypes.func,
   onBeforeLoad: PropTypes.func,
   onValidate: PropTypes.func,
   minLines: PropTypes.number,

--- a/src/editorOptions.js
+++ b/src/editorOptions.js
@@ -17,6 +17,7 @@ const editorEvents = [
   'onCopy',
   'onPaste',
   'onSelectionChange',
+  'onCursorChange',
   'onScroll',
   'handleOptions',
   'updateRef',

--- a/src/split.js
+++ b/src/split.js
@@ -79,6 +79,7 @@ export default class SplitComponent extends Component {
       editor.on('paste', this.onPaste);
       editor.on('change', this.onChange);
       editor.getSession().selection.on('changeSelection', this.onSelectionChange);
+      editor.getSession().selection.on('changeCursor', this.onCursorChange);
       editor.session.on('changeScrollTop', this.onScroll);
       editor.setValue(defaultValueForEditor === undefined ? valueForEditor : defaultValueForEditor, cursorStart);
       const newAnnotations = get(annotations, index, [])
@@ -247,7 +248,15 @@ export default class SplitComponent extends Component {
       this.props.onSelectionChange(value, event);
     }
   }
-
+  onCursorChange(event) {
+    if(this.props.onCursorChange) {
+      let value = []
+      this.editor.env.split.forEach((editor) => {
+        value.push(editor.getSelection())
+      })
+      this.props.onCursorChange(value, event)
+    }
+  }
   onFocus(event) {
     if (this.props.onFocus) {
       this.props.onFocus(event);
@@ -356,6 +365,7 @@ SplitComponent.propTypes = {
   defaultValue: PropTypes.arrayOf(PropTypes.string),
   onLoad: PropTypes.func,
   onSelectionChange: PropTypes.func,
+  onCursorChange: PropTypes.func,
   onBeforeLoad: PropTypes.func,
   minLines: PropTypes.number,
   maxLines: PropTypes.number,

--- a/tests/src/ace.spec.js
+++ b/tests/src/ace.spec.js
@@ -318,6 +318,25 @@ describe('Ace Component', () => {
       wrapper.instance().editor.getSession().selection.selectAll()
     });
 
+    it('should call the onCursorChange method callback', (done) => {
+      let onCursorChange = function(){}
+      const value =`
+        function main(value) {
+          console.log('hi james')
+          return value;
+        }
+      `
+
+      const wrapper = mount(<AceEditor value={value} />, mountOptions);
+      onCursorChange = function (selection) {
+        expect(selection.getCursor()).to.deep.equal({ row: 0, column: 0 })
+        done()
+      }
+      wrapper.setProps({onCursorChange}) 
+      expect(wrapper.instance().editor.getSession().selection.getCursor()).to.deep.equal({row: 5, column: 6})
+      wrapper.instance().editor.getSession().selection.moveCursorTo(0, 0)
+    });
+
     it('should call the onBlur method callback', () => {
       const onBlurCallback = sinon.spy();
       const wrapper = mount(<AceEditor onBlur={onBlurCallback}/>, mountOptions);

--- a/tests/src/split.spec.js
+++ b/tests/src/split.spec.js
@@ -225,6 +225,20 @@ describe('Split Component', () => {
       expect(onSelectionChangeCallback.callCount).to.equal(1);
     });
 
+    it('should call the onCursorChange method callback', () => {
+      const onCursorChangeCallback = sinon.spy();
+
+      const wrapper = mount(<SplitEditor value="a" onCursorChange={onCursorChangeCallback}/>, mountOptions) 
+
+      // The changeCursor event is called when the initial value is set
+      expect(onCursorChangeCallback.callCount).to.equal(1);
+
+      // Trigger the changeCursor event
+      wrapper.instance().splitEditor.getSession().selection.moveCursorTo(0, 0);
+      
+      expect(onCursorChangeCallback.callCount).to.equal(2);
+    });
+
     it('should call the onBlur method callback', () => {
       const onBlurCallback = sinon.spy();
       const wrapper = mount(<SplitEditor onBlur={onBlurCallback}/>, mountOptions);


### PR DESCRIPTION
# What's in this PR?

Added changeCursor event. 

## List the changes you made and your reasons for them.

I wanted to detect that the position of the cursor was changed.
Ace emitted a changeCursor event, but react-ace did not have a handler to receive it, I added it. 😄 

