### PR TITLE
Add links to 'brace' to improve doc

### DIFF
--- a/docs/Modes.md
+++ b/docs/Modes.md
@@ -1,6 +1,6 @@
 # Modes, Themes, and Keyboard Handlers
 
-All modes, themes, and keyboard handlers should be required through ```brace``` directly.  Browserify will grab these modes / themes / keyboard handlers through ```brace``` and will be available at run time.  See the example above.  This prevents bloating the compiled javascript with extra modes and themes for your application.
+All modes, themes, and keyboard handlers should be required through [`brace`](https://github.com/thlorenz/brace) directly.  Browserify will grab these [modes](https://github.com/thlorenz/brace/tree/master/mode) / [themes](https://github.com/thlorenz/brace/tree/master/theme) / [keyboard handlers](https://github.com/thlorenz/brace/tree/master/keybinding) through ```brace``` and will be available at run time.  See the example above.  This prevents bloating the compiled javascript with extra modes and themes for your application.
 
 ### Example Modes
 


### PR DESCRIPTION
# What's in this PR?
Added links on doc for brace, brace/mode, brace/theme & brace/keybinding, under the topic _'How to add modes, themes and keyboard handlers'_

## References
https://github.com/thlorenz/brace
https://github.com/thlorenz/brace/tree/master/mode
https://github.com/thlorenz/brace/tree/master/theme
https://github.com/thlorenz/brace/tree/master/keybinding
