### PR TITLE
Clarified markers doc and fixed link

### DIFF
--- a/docs/Ace.md
+++ b/docs/Ace.md
@@ -79,5 +79,5 @@ render(
 |keyboardHandler| | String | corresponding to the keybinding mode to set (such as vim or emacs)|
 |commands| | Array | new commands to add to the editor
 |annotations| | Array | annotations to show in the editor i.e. `[{ row: 0, column: 2, type: 'error', text: 'Some error.'}]`, displayed in the gutter|
-|markers| | Array | [markers](https://ace.c9.io/api/edit_session.html#EditSession.addMarker) to show in the editor, i.e. `[{ startRow: 0, startCol: 2, endRow: 1, endCol: 20, className: 'error-marker', type: 'background' }]`|
+|markers| | Array | [markers](https://ace.c9.io/#nav=api&api=edit_session) to show in the editor, i.e. `[{ startRow: 0, startCol: 2, endRow: 1, endCol: 20, className: 'error-marker', type: 'background' }]`. Make sure to define the class (eg. ".error-marker") and set `position: absolute` for it.|
 |style| | Object  | camelCased properties |


### PR DESCRIPTION
# What's in this PR?

Just a doc update as it was not clear that the CSS class for markers needed to have `position: absolute`