### PR TITLE
add className to diff.js

### DIFF
--- a/src/diff.js
+++ b/src/diff.js
@@ -184,6 +184,7 @@ export default class DiffComponent extends Component {
     return (
       <SplitEditor
         name={this.props.name}
+        className={this.props.className}
         focus={this.props.focus}
         orientation={this.props.orientation}
         splits={this.props.splits}
@@ -231,6 +232,7 @@ DiffComponent.propTypes = {
   minLines: PropTypes.func,
   mode: PropTypes.string,
   name: PropTypes.string,
+  className: PropTypes.string,
   onLoad: PropTypes.func,
   onPaste: PropTypes.func,
   onScroll: PropTypes.func,


### PR DESCRIPTION
# What's in this PR?
adds `className` prop to `diff.js` to be passed down to `split.js`

## List the changes you made and your reasons for them.
add `className` to `diff.js`

Make sure any changes to code include changes to documentation.

## References

### Fixes #

### Progress on: #