### PR TITLE
On receiving props, process editor value update in priority

### DIFF
--- a/src/ace.js
+++ b/src/ace.js
@@ -122,8 +122,6 @@ export default class ReactAce extends Component {
     this.editor.resize();
   }
 
-  
-
   componentWillReceiveProps(nextProps) {
     const oldProps = this.props;
 
@@ -143,6 +141,16 @@ export default class ReactAce extends Component {
         appliedClassesArray.splice(index, 1);
       });
       this.refEditor.className = ' ' + nextProps.className + ' ' + appliedClassesArray.join(' ');
+    }
+
+    // First process editor value, as it may create a new session (see issue #300)
+    if (this.editor && this.editor.getValue() !== nextProps.value) {
+      // editor.setValue is a synchronous function call, change event is emitted before setValue return.
+      this.silent = true;
+      const pos = this.editor.session.selection.toJSON();
+      this.editor.setValue(nextProps.value, nextProps.cursorStart);
+      this.editor.session.selection.fromJSON(pos);
+      this.silent = false;
     }
 
     if (nextProps.mode !== oldProps.mode) {
@@ -183,14 +191,6 @@ export default class ReactAce extends Component {
     // this doesn't look like it works at all....
     if (!isEqual(nextProps.scrollMargin, oldProps.scrollMargin)) {
       this.handleScrollMargins(nextProps.scrollMargin)
-    }
-    if (this.editor && this.editor.getValue() !== nextProps.value) {
-      // editor.setValue is a synchronous function call, change event is emitted before setValue return.
-      this.silent = true;
-      const pos = this.editor.session.selection.toJSON();
-      this.editor.setValue(nextProps.value, nextProps.cursorStart);
-      this.editor.session.selection.fromJSON(pos);
-      this.silent = false;
     }
 
     if (nextProps.focus && !oldProps.focus) {

--- a/tests/src/ace.spec.js
+++ b/tests/src/ace.spec.js
@@ -226,6 +226,23 @@ describe('Ace Component', () => {
       expect(editor.getSession().getAnnotations()).to.deep.equal([]);
     })
 
+    it('should add annotations with changing editor value', () => {
+      // See https://github.com/securingsincity/react-ace/issues/300
+      const annotations = [{ row: 0, column: 0, text: 'error.message', type: 'error' }];
+      const initialText = `Initial
+      text`;
+      const modifiedText = `Modified
+      text`;
+      const wrapper = mount(<AceEditor annotations={[]} value={initialText}/>, mountOptions);
+      const editor = wrapper.instance().editor;
+      wrapper.setProps({
+        annotations: annotations,
+        value: modifiedText
+      });
+      expect(editor.renderer.$gutterLayer.$annotations).to.have.length(1);
+      expect(editor.renderer.$gutterLayer.$annotations[0]).to.have.property('className');
+    })
+
     it('should set editor to null on componentWillUnmount', () => {
       const wrapper = mount(<AceEditor />, mountOptions);
       expect(wrapper.getElement().editor).to.not.equal(null);


### PR DESCRIPTION
See #300 / https://github.com/securingsincity/react-ace/issues/300#issuecomment-401008555

Changing updates processing order when receiving props.
The issue was annotations that sometimes could not be set.

It seems related to the session management in ace. I think when the text is changed, a new session is created and the annotation change event somehow misses its session.
