### PR TITLE
Update types.d.ts

### DIFF
--- a/types.d.ts
+++ b/types.d.ts
@@ -150,6 +150,7 @@ export interface AceEditorProps {
     onLoad?: (editor: EditorProps) => void
     onBeforeLoad?: (ace: any) => void
     onChange?: (value: string, event?: any) => void
+    onInput?: (value: string, event?: any) => void
     onSelection?: (selectedText: string, event?: any) => void
     onCopy?: (value: string) => void
     onPaste?: (value: string) => void


### PR DESCRIPTION
# What's in this PR?

Typings file missed Autumn 2017 `onInput` prop addition. 

## List the changes you made and your reasons for them.

Added definition to `types.d.ts`. Otherwise cripples TypeScript compilations seeking to use the event. 

Already exists in code and docs, just not typings 🔢 


--- 
Also using this opportunity to say thanks for the easy implementation. It's a breeze.