### PR TITLE
AceOptions interface missing debounceChangePeriod

### DIFF
--- a/types.d.ts
+++ b/types.d.ts
@@ -91,6 +91,7 @@ export interface AceOptions {
     enableSnippets?: boolean
     spellcheck?: boolean
     useElasticTabstops?: boolean
+    debounceChangePeriod?: number
 }
 
 export interface EditorProps {


### PR DESCRIPTION
# What's in this PR?
The Typescript interface for AceOptions was missing debounceChangePeriod option

## List the changes you made and your reasons for them.
I added debounceChangePeriod to the the interface

Make sure any changes to code include changes to documentation.

## References

### Fixes #
TypeScript complains if you try to use that prop

### Progress on: #