### PR TITLE
Adding compatibility for React >= 17

### DIFF
--- a/src/ace.js
+++ b/src/ace.js
@@ -122,8 +122,9 @@ export default class ReactAce extends Component {
     this.editor.resize();
   }
 
-  componentWillReceiveProps(nextProps) {
-    const oldProps = this.props;
+  componentDidUpdate(prevProps) {
+    const oldProps = prevProps;
+    const nextProps = this.props;
 
     for (let i = 0; i < editorOptions.length; i++) {
       const option = editorOptions[i];
@@ -193,14 +194,11 @@ export default class ReactAce extends Component {
       this.handleScrollMargins(nextProps.scrollMargin)
     }
 
-    if (nextProps.focus && !oldProps.focus) {
-      this.editor.focus();
-    }
-  }
-
-  componentDidUpdate(prevProps) {
     if(prevProps.height !== this.props.height || prevProps.width !== this.props.width){
       this.editor.resize();
+    }
+    if (this.props.focus && !prevProps.focus) {
+      this.editor.focus();
     }
   }
 

--- a/src/diff.js
+++ b/src/diff.js
@@ -13,8 +13,8 @@ export default class DiffComponent extends Component {
     this.diff = this.diff.bind(this);
   }
 
-  componentWillReceiveProps(props) {
-    const {value} = props;
+  componentDidUpdate() {
+    const {value} = this.props;
 
     if (value !== this.state.value) {
       this.setState({value});

--- a/src/split.js
+++ b/src/split.js
@@ -137,8 +137,9 @@ export default class SplitComponent extends Component {
     }
   }
 
-  componentWillReceiveProps(nextProps) {
-    const oldProps = this.props;
+  componentDidUpdate(prevProps) {
+    const oldProps = prevProps;
+    const nextProps = this.props;
 
     const split = this.editor.env.split
 

--- a/tests/src/ace.spec.js
+++ b/tests/src/ace.spec.js
@@ -496,9 +496,9 @@ describe('Ace Component', () => {
 
   });
 
-  describe('ComponentWillReceiveProps', () => {
+  describe('ComponentDidUpdate', () => {
 
-    it('should update the editorOptions on componentWillReceiveProps', () => {
+    it('should update the editorOptions on componentDidUpdate', () => {
       const options = {
         printMargin: 80
       };
@@ -508,7 +508,7 @@ describe('Ace Component', () => {
       const editor = wrapper.instance().editor;
       expect(editor.getOption('printMargin')).to.equal(options.printMargin);
 
-      // Now trigger the componentWillReceiveProps
+      // Now trigger the componentDidUpdate
       const newOptions = {
         printMargin: 200,
         animatedScroll: true,
@@ -518,7 +518,7 @@ describe('Ace Component', () => {
       expect(editor.getOption('animatedScroll')).to.equal(newOptions.animatedScroll);
     });
 
-    it('should update the editorOptions on componentWillReceiveProps', () => {
+    it('should update the editorOptions on componentDidUpdate', () => {
 
       const wrapper = mount(<AceEditor minLines={1} />, mountOptions);
 
@@ -532,7 +532,7 @@ describe('Ace Component', () => {
     });
 
 
-    it('should update the mode on componentWillReceiveProps', () => {
+    it('should update the mode on componentDidUpdate', () => {
 
       const wrapper = mount(<AceEditor mode="javascript" />, mountOptions);
 
@@ -547,7 +547,7 @@ describe('Ace Component', () => {
 
 
 
-    it('should update many props on componentWillReceiveProps', () => {
+    it('should update many props on componentDidUpdate', () => {
 
       const wrapper = mount((
         <AceEditor
@@ -580,7 +580,7 @@ describe('Ace Component', () => {
 
 
 
-    it('should update the className on componentWillReceiveProps', () => {
+    it('should update the className on componentDidUpdate', () => {
       const className = 'old-class';
       const wrapper = mount(<AceEditor className={className}/>, mountOptions);
 
@@ -588,7 +588,7 @@ describe('Ace Component', () => {
       let editor = wrapper.instance().refEditor;
       expect(editor.className).to.equal(' ace_editor ace-tm old-class');
 
-      // Now trigger the componentWillReceiveProps
+      // Now trigger the componentDidUpdate
       const newClassName = 'new-class';
       wrapper.setProps({className: newClassName});
       editor = wrapper.instance().refEditor;
@@ -596,7 +596,7 @@ describe('Ace Component', () => {
     });
 
 
-    it('should update the value on componentWillReceiveProps', () => {
+    it('should update the value on componentDidUpdate', () => {
       const startValue = 'start value';
       const wrapper = mount(<AceEditor value={startValue}/>, mountOptions);
 
@@ -604,21 +604,21 @@ describe('Ace Component', () => {
       let editor = wrapper.instance().editor;
       expect(editor.getValue()).to.equal(startValue);
 
-      // Now trigger the componentWillReceiveProps
+      // Now trigger the componentDidUpdate
       const newValue = 'updated value';
       wrapper.setProps({value: newValue});
       editor = wrapper.instance().editor;
       expect(editor.getValue()).to.equal(newValue);
     });
 
-    it('should trigger the focus on componentWillReceiveProps', () => {
+    it('should trigger the focus on componentDidUpdate', () => {
       const onFocusCallback = sinon.spy();
       const wrapper = mount(<AceEditor onFocus={onFocusCallback}/>, mountOptions);
 
       // Read the focus
       expect(onFocusCallback.callCount).to.equal(0);
 
-      // Now trigger the componentWillReceiveProps
+      // Now trigger the componentDidUpdate
       wrapper.setProps({focus: true});
       expect(onFocusCallback.callCount).to.equal(1);
     });

--- a/tests/src/ace.spec.js
+++ b/tests/src/ace.spec.js
@@ -249,7 +249,7 @@ describe('Ace Component', () => {
 
       // Check the editor is null after the Unmount
       wrapper.unmount();
-      expect(wrapper.get(0)).to.equal(undefined);
+      expect(wrapper.get(0)).to.not.exist;
     });
 
   });

--- a/tests/src/ace.spec.js
+++ b/tests/src/ace.spec.js
@@ -249,7 +249,7 @@ describe('Ace Component', () => {
 
       // Check the editor is null after the Unmount
       wrapper.unmount();
-      expect(wrapper.getElement()).to.equal(null);
+      expect(wrapper.get(0)).to.equal(undefined);
     });
 
   });

--- a/tests/src/split.spec.js
+++ b/tests/src/split.spec.js
@@ -144,7 +144,7 @@ describe('Split Component', () => {
 
       // Check the editor is null after the Unmount
       wrapper.unmount();
-      expect(wrapper.getElement()).to.equal(null);
+      expect(wrapper.get(0)).to.equal(undefined);
     });
 
 

--- a/tests/src/split.spec.js
+++ b/tests/src/split.spec.js
@@ -51,7 +51,7 @@ describe('Split Component', () => {
       expect(editor.test).to.equal(editorProperties.test);
     });
 
-    it('should update the orientation on componentWillReceiveProps', () => {
+    it('should update the orientation on componentDidUpdate', () => {
       let orientation = 'below';
       const wrapper = mount(<SplitEditor orientation={orientation} splits={2}/>, mountOptions);
 
@@ -59,21 +59,21 @@ describe('Split Component', () => {
       let editor = wrapper.instance().split;
       expect(editor.getOrientation()).to.equal(editor.BELOW);
 
-      // Now trigger the componentWillReceiveProps
+      // Now trigger the componentDidUpdate
       orientation = 'beside';
       wrapper.setProps({orientation});
       editor = wrapper.instance().split;
       expect(editor.getOrientation()).to.equal(editor.BESIDE);
     });
 
-    it('should update the orientation on componentWillReceiveProps', () => {
+    it('should update the orientation on componentDidUpdate', () => {
       const wrapper = mount(<SplitEditor  splits={2}/>, mountOptions);
 
       // Read set value
       let editor = wrapper.instance().split;
       expect(editor.getSplits()).to.equal(2);
 
-      // Now trigger the componentWillReceiveProps
+      // Now trigger the componentDidUpdate
       wrapper.setProps({splits: 4});
       editor = wrapper.instance().split;
       expect(editor.getSplits()).to.equal(4);
@@ -214,7 +214,7 @@ describe('Split Component', () => {
 
     it('should call the onSelectionChange method callback', () => {
       const onSelectionChangeCallback = sinon.spy();
-      const wrapper = mount(<SplitEditor onSelectionChange={onSelectionChangeCallback}/>, mountOptions);
+      const wrapper = mount(<SplitEditor onSelectionChange={onSelectionChangeCallback} value="some value"/>, mountOptions);
 
       // Check is not previously called
       expect(onSelectionChangeCallback.callCount).to.equal(0);
@@ -264,9 +264,9 @@ describe('Split Component', () => {
     });
 
   });
-  describe('ComponentWillReceiveProps', () => {
+  describe('ComponentDidUpdate', () => {
 
-    it('should update the editorOptions on componentWillReceiveProps', () => {
+    it('should update the editorOptions on componentDidUpdate', () => {
       const options = {
         printMargin: 80
       };
@@ -276,7 +276,7 @@ describe('Split Component', () => {
       const editor = wrapper.instance().splitEditor;
       expect(editor.getOption('printMargin')).to.equal(options.printMargin);
 
-      // Now trigger the componentWillReceiveProps
+      // Now trigger the componentDidUpdate
       const newOptions = {
         printMargin: 200,
         animatedScroll: true,
@@ -285,7 +285,7 @@ describe('Split Component', () => {
       expect(editor.getOption('printMargin')).to.equal(newOptions.printMargin);
       expect(editor.getOption('animatedScroll')).to.equal(newOptions.animatedScroll);
     });
-    it('should update the editorOptions on componentWillReceiveProps', () => {
+    it('should update the editorOptions on componentDidUpdate', () => {
 
       const wrapper = mount(<SplitEditor minLines={1} />, mountOptions);
 
@@ -299,7 +299,7 @@ describe('Split Component', () => {
     });
 
 
-    it('should update the mode on componentWillReceiveProps', () => {
+    it('should update the mode on componentDidUpdate', () => {
 
       const wrapper = mount(<SplitEditor mode="javascript" />, mountOptions);
 
@@ -314,7 +314,7 @@ describe('Split Component', () => {
 
 
 
-    it('should update many props on componentWillReceiveProps', () => {
+    it('should update many props on componentDidUpdate', () => {
 
       const wrapper = mount((
         <SplitEditor
@@ -347,7 +347,7 @@ describe('Split Component', () => {
 
 
 
-    it('should update the className on componentWillReceiveProps', () => {
+    it('should update the className on componentDidUpdate', () => {
       const className = 'old-class';
       const wrapper = mount(<SplitEditor className={className}/>, mountOptions);
 
@@ -355,7 +355,7 @@ describe('Split Component', () => {
       let editor = wrapper.instance().refEditor;
       expect(editor.className).to.equal(' ace_editor ace-tm old-class');
 
-      // Now trigger the componentWillReceiveProps
+      // Now trigger the componentDidUpdate
       const newClassName = 'new-class';
       wrapper.setProps({className: newClassName});
       editor = wrapper.instance().refEditor;
@@ -363,7 +363,7 @@ describe('Split Component', () => {
     });
 
 
-    it('should update the value on componentWillReceiveProps', () => {
+    it('should update the value on componentDidUpdate', () => {
       const startValue = 'start value';
       const anotherStartValue = 'another start value';
       const wrapper = mount(<SplitEditor value={[startValue, anotherStartValue]}/>, mountOptions);
@@ -374,7 +374,7 @@ describe('Split Component', () => {
       expect(editor.getValue()).to.equal(startValue);
       expect(editor2.getValue()).to.equal(anotherStartValue);
 
-      // Now trigger the componentWillReceiveProps
+      // Now trigger the componentDidUpdate
       const newValue = 'updated value';
       const anotherNewValue = 'another updated value';
       wrapper.setProps({value: [newValue, anotherNewValue]});
@@ -474,14 +474,14 @@ describe('Split Component', () => {
       expect(editor.getSession().getAnnotations()).to.deep.equal([]);
     })
 
-    it('should trigger the focus on componentWillReceiveProps', () => {
+    it('should trigger the focus on componentDidUpdate', () => {
       const onFocusCallback = sinon.spy();
       const wrapper = mount(<SplitEditor onFocus={onFocusCallback}/>, mountOptions);
 
       // Read the focus
       expect(onFocusCallback.callCount).to.equal(0);
 
-      // Now trigger the componentWillReceiveProps
+      // Now trigger the componentDidUpdate
       wrapper.setProps({focus: true});
       expect(onFocusCallback.callCount).to.equal(1);
     });

--- a/tests/src/split.spec.js
+++ b/tests/src/split.spec.js
@@ -144,7 +144,7 @@ describe('Split Component', () => {
 
       // Check the editor is null after the Unmount
       wrapper.unmount();
-      expect(wrapper.get(0)).to.equal(undefined);
+      expect(wrapper.get(0)).to.not.exist;
     });
 
 


### PR DESCRIPTION
# What's in this PR?

Starting with React 16.3, several lifecycle functions are aliased to versions prefixed with `UNSAFE_` indicating that their usage is discouraged. In future versions they will be deprecated and removed[1]. One of them, `componentWillReceiveProps`, is heavily used in `react-ace`. To act proactively, this PR is removing the usage of this lifecycle function.

Additionally, some test failures due to changes in the shallow wrapper were addressed.

## List the changes you made and your reasons for them.

Usages of `componentWillReceiveProps` in `AceEditor` & `SplitEditor` components are moved to the `componentDidUpdate` function.

## References

[1]: https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html

### Fixes #

### Progress on: #