### PR TITLE
Replacing `brace` with `ace-builds`.

### DIFF
--- a/example/diff.js
+++ b/example/diff.js
@@ -2,8 +2,10 @@ import React, { Component } from 'react';
 import { render } from 'react-dom';
 import {diff as DiffEditor} from '../src/index.js';
 
-import 'ace/mode/jsx';
-import 'ace/ext/searchbox';
+import ace from 'ace-builds';
+
+ace.require('ace/mode/jsx');
+ace.require('ace/ext/searchbox');
 
 const defaultValue = [
   `// Use this tool to display differences in code.
@@ -34,8 +36,8 @@ const languages = [
 ];
 
 languages.forEach((lang) => {
-  require(`ace/mode/${lang}`)
-  require(`ace/snippets/${lang}`)
+  ace.require(`ace/mode/${lang}`)
+  ace.require(`ace/snippets/${lang}`)
 })
 
 class App extends Component {

--- a/example/diff.js
+++ b/example/diff.js
@@ -3,6 +3,7 @@ import { render } from 'react-dom';
 import {diff as DiffEditor} from '../src/index.js';
 
 import ace from 'ace-builds';
+import 'ace-builds/webpack-resolver';
 
 ace.require('ace/mode/jsx');
 ace.require('ace/ext/searchbox');

--- a/example/diff.js
+++ b/example/diff.js
@@ -2,8 +2,8 @@ import React, { Component } from 'react';
 import { render } from 'react-dom';
 import {diff as DiffEditor} from '../src/index.js';
 
-import 'brace/mode/jsx';
-import 'brace/ext/searchbox';
+import 'ace/mode/jsx';
+import 'ace/ext/searchbox';
 
 const defaultValue = [
   `// Use this tool to display differences in code.
@@ -34,8 +34,8 @@ const languages = [
 ];
 
 languages.forEach((lang) => {
-  require(`brace/mode/${lang}`)
-  require(`brace/snippets/${lang}`)
+  require(`ace/mode/${lang}`)
+  require(`ace/snippets/${lang}`)
 })
 
 class App extends Component {

--- a/example/index.js
+++ b/example/index.js
@@ -1,7 +1,9 @@
 import React, { Component } from 'react';
 import { render } from 'react-dom';
 import AceEditor from '../src/ace.js';
-import 'ace/mode/jsx';
+import ace from 'ace-builds';
+
+ace.require('ace/mode/jsx');
 
 const languages = [
   'javascript',
@@ -36,16 +38,16 @@ const themes = [
 ]
 
 languages.forEach((lang) => {
-  require(`ace/mode/${lang}`)
-  require(`ace/snippets/${lang}`)
+  ace.require(`ace/mode/${lang}`)
+  ace.require(`ace/snippets/${lang}`)
 })
 
 themes.forEach((theme) => {
-  require(`ace/theme/${theme}`)
+  ace.require(`ace/theme/${theme}`)
 })
 /*eslint-disable no-alert, no-console */
-import 'ace/ext/language_tools';
-import 'ace/ext/searchbox';
+ace.require('ace/ext/language_tools');
+ace.require('ace/ext/searchbox');
 
 const defaultValue =
 `function onLoad(editor) {

--- a/example/index.js
+++ b/example/index.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import { render } from 'react-dom';
 import AceEditor from '../src/ace.js';
 import ace from 'ace-builds';
+import 'ace-builds/webpack-resolver';
 
 ace.require('ace/mode/jsx');
 

--- a/example/index.js
+++ b/example/index.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import { render } from 'react-dom';
 import AceEditor from '../src/ace.js';
-import 'brace/mode/jsx';
+import 'ace/mode/jsx';
 
 const languages = [
   'javascript',
@@ -36,17 +36,16 @@ const themes = [
 ]
 
 languages.forEach((lang) => {
-  require(`brace/mode/${lang}`)
-  require(`brace/snippets/${lang}`)
+  require(`ace/mode/${lang}`)
+  require(`ace/snippets/${lang}`)
 })
 
 themes.forEach((theme) => {
-  require(`brace/theme/${theme}`)
+  require(`ace/theme/${theme}`)
 })
 /*eslint-disable no-alert, no-console */
-import 'brace/ext/language_tools';
-import 'brace/ext/searchbox';
-
+import 'ace/ext/language_tools';
+import 'ace/ext/searchbox';
 
 const defaultValue =
 `function onLoad(editor) {

--- a/example/split.js
+++ b/example/split.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import { render } from 'react-dom';
 import SplitAceEditor from '../src/split.js';
 import ace from 'ace-builds';
+import 'ace-builds/webpack-resolver';
 
 ace.require('ace/mode/jsx');
 ace.require('ace/ext/searchbox');

--- a/example/split.js
+++ b/example/split.js
@@ -1,9 +1,10 @@
 import React, { Component } from 'react';
 import { render } from 'react-dom';
 import SplitAceEditor from '../src/split.js';
+import ace from 'ace-builds';
 
-import 'ace/mode/jsx';
-import 'ace/ext/searchbox';
+ace.require('ace/mode/jsx');
+ace.require('ace/ext/searchbox');
 
 const languages = [
   'javascript',
@@ -38,16 +39,15 @@ const themes = [
 ]
 
 languages.forEach((lang) => {
-  require(`ace/mode/${lang}`)
-  require(`ace/snippets/${lang}`)
+  ace.require(`ace/mode/${lang}`)
+  ace.require(`ace/snippets/${lang}`)
 })
 
 themes.forEach((theme) => {
-  require(`ace/theme/${theme}`)
+  ace.require(`ace/theme/${theme}`)
 })
 /*eslint-disable no-alert, no-console */
-import 'ace/ext/language_tools';
-
+ace.require('ace/ext/language_tools');
 
 const defaultValue = [
   `function onLoad(editor) {

--- a/example/split.js
+++ b/example/split.js
@@ -2,8 +2,8 @@ import React, { Component } from 'react';
 import { render } from 'react-dom';
 import SplitAceEditor from '../src/split.js';
 
-import 'brace/mode/jsx';
-import 'brace/ext/searchbox';
+import 'ace/mode/jsx';
+import 'ace/ext/searchbox';
 
 const languages = [
   'javascript',
@@ -38,15 +38,15 @@ const themes = [
 ]
 
 languages.forEach((lang) => {
-  require(`brace/mode/${lang}`)
-  require(`brace/snippets/${lang}`)
+  require(`ace/mode/${lang}`)
+  require(`ace/snippets/${lang}`)
 })
 
 themes.forEach((theme) => {
-  require(`brace/theme/${theme}`)
+  require(`ace/theme/${theme}`)
 })
 /*eslint-disable no-alert, no-console */
-import 'brace/ext/language_tools';
+import 'ace/ext/language_tools';
 
 
 const defaultValue = [

--- a/package-lock.json
+++ b/package-lock.json
@@ -410,6 +410,11 @@
         "negotiator": "0.6.1"
       }
     },
+    "ace-builds": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/ace-builds/-/ace-builds-1.4.1.tgz",
+      "integrity": "sha512-ulsfTOi/oAXBIt9hYlK4asyFZYsFOOUAbwBZidbjWWJycRX4LtwIithMyndcnoQ4PavkZ0iGJ+c9nqHNiYbubA=="
+    },
     "acorn": {
       "version": "5.7.3",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
@@ -1836,11 +1841,6 @@
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
       "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24=",
       "dev": true
-    },
-    "brace": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/brace/-/brace-0.11.1.tgz",
-      "integrity": "sha1-SJb8ydVE7vRfS7dmDbMg07N5/lg="
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -4370,6 +4370,15 @@
             "code-point-at": "1.1.0",
             "is-fullwidth-code-point": "1.0.0",
             "strip-ansi": "3.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "safe-buffer": "5.1.1"
           }
         },
         "string_decoder": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -478,14 +478,12 @@
     "ajv-errors": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-1.0.0.tgz",
-      "integrity": "sha1-7PAh+hCP0X37Xms4Py3SM+Mf/Fk=",
-      "dev": true
+      "integrity": "sha1-7PAh+hCP0X37Xms4Py3SM+Mf/Fk="
     },
     "ajv-keywords": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.2.0.tgz",
-      "integrity": "sha1-6GuBnGAs+IIa1jdBNpjx3sAhhHo=",
-      "dev": true
+      "integrity": "sha1-6GuBnGAs+IIa1jdBNpjx3sAhhHo="
     },
     "ansi-colors": {
       "version": "3.0.5",
@@ -1769,8 +1767,7 @@
     "big.js": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.2.0.tgz",
-      "integrity": "sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q==",
-      "dev": true
+      "integrity": "sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q=="
     },
     "binary-extensions": {
       "version": "1.11.0",
@@ -2978,8 +2975,7 @@
     "emojis-list": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
-      "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k=",
-      "dev": true
+      "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k="
     },
     "encodeurl": {
       "version": "1.0.2",
@@ -3671,8 +3667,7 @@
     "fast-json-stable-stringify": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
-      "dev": true
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
     },
     "fast-levenshtein": {
       "version": "2.0.6",
@@ -3706,6 +3701,48 @@
       "requires": {
         "flat-cache": "1.3.0",
         "object-assign": "4.1.1"
+      }
+    },
+    "file-loader": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/file-loader/-/file-loader-2.0.0.tgz",
+      "integrity": "sha512-YCsBfd1ZGCyonOKLxPiKPdu+8ld9HAaMEvJewzz+b2eTF7uL5Zm/HdBF6FjCrpCMRq25Mi0U1gl4pwn2TlH7hQ==",
+      "requires": {
+        "loader-utils": "1.1.0",
+        "schema-utils": "1.0.0"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "6.5.3",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.3.tgz",
+          "integrity": "sha512-LqZ9wY+fx3UMiiPd741yB2pj3hhil+hQc8taf4o2QGRFpWgZ2V5C8HA165DY9sS3fJwsk7uT7ZlFEyC3Ig3lLg==",
+          "requires": {
+            "fast-deep-equal": "2.0.1",
+            "fast-json-stable-stringify": "2.0.0",
+            "json-schema-traverse": "0.4.1",
+            "uri-js": "4.2.2"
+          }
+        },
+        "fast-deep-equal": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+          "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
+        },
+        "json-schema-traverse": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+        },
+        "schema-utils": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
+          "integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
+          "requires": {
+            "ajv": "6.5.3",
+            "ajv-errors": "1.0.0",
+            "ajv-keywords": "3.2.0"
+          }
+        }
       }
     },
     "filename-regex": {
@@ -5933,8 +5970,7 @@
     "json5": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
-      "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
-      "dev": true
+      "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
     },
     "jsprim": {
       "version": "1.4.1",
@@ -6033,7 +6069,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
       "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
-      "dev": true,
       "requires": {
         "big.js": "3.2.0",
         "emojis-list": "2.1.0",
@@ -10415,7 +10450,6 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
       "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
-      "dev": true,
       "requires": {
         "punycode": "2.1.1"
       },
@@ -10423,8 +10457,7 @@
         "punycode": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-          "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-          "dev": true
+          "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
   "dependencies": {
     "ace-builds": "^1.4.1",
     "diff-match-patch": "^1.0.4",
+    "file-loader": "^2.0.0",
     "lodash.get": "^4.4.2",
     "lodash.isequal": "^4.5.0",
     "prop-types": "^15.6.2"

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "brace"
   ],
   "dependencies": {
-    "brace": "^0.11.1",
+    "ace-builds": "^1.4.1",
     "diff-match-patch": "^1.0.4",
     "lodash.get": "^4.4.2",
     "lodash.isequal": "^4.5.0",

--- a/src/ace.js
+++ b/src/ace.js
@@ -1,9 +1,8 @@
-import ace from 'brace'
+import ace, { Range } from 'ace-builds'
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import isEqual from 'lodash.isequal'
 
-const { Range } = ace.acequire('ace/range');
 import { editorOptions, editorEvents,debounce } from './editorOptions.js'
 
 export default class ReactAce extends Component {
@@ -366,7 +365,7 @@ ReactAce.propTypes = {
 };
 
 ReactAce.defaultProps = {
-  name: 'brace-editor',
+  name: 'ace-editor',
   focus: false,
   mode: '',
   theme: '',

--- a/src/ace.js
+++ b/src/ace.js
@@ -1,4 +1,5 @@
 import ace, { Range } from 'ace-builds'
+import 'ace-builds/webpack-resolver';
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import isEqual from 'lodash.isequal'

--- a/src/ace.js
+++ b/src/ace.js
@@ -1,5 +1,4 @@
 import ace, { Range } from 'ace-builds'
-import 'ace-builds/webpack-resolver';
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import isEqual from 'lodash.isequal'

--- a/src/diff.js
+++ b/src/diff.js
@@ -272,7 +272,7 @@ DiffComponent.defaultProps = {
   maxLines: null,
   minLines: null,
   mode: '',
-  name: 'brace-editor',
+  name: 'ace-editor',
   onLoad: null,
   onScroll: null,
   onPaste: null,

--- a/src/split.js
+++ b/src/split.js
@@ -1,15 +1,12 @@
-import ace from 'brace'
-import {UndoManager} from 'brace';
+import ace from 'ace-builds'
+import { Range, UndoManager } from 'ace-builds';
+import { Split } from 'ace-builds/src-noconflict/ext-split';
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import isEqual from 'lodash.isequal'
 import get from 'lodash.get'
 
 import { editorOptions, editorEvents,debounce } from './editorOptions.js'
-const { Range } = ace.acequire('ace/range');
-
-import 'brace/ext/split'
-const { Split } = ace.acequire('ace/split');
 
 export default class SplitComponent extends Component {
   constructor(props) {
@@ -402,7 +399,7 @@ SplitComponent.propTypes = {
 };
 
 SplitComponent.defaultProps = {
-  name: 'brace-editor',
+  name: 'ace-editor',
   focus: false,
   orientation: 'beside',
   splits: 2,

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -1,6 +1,6 @@
 
 const { JSDOM } = require('jsdom');
-const jsdom = new JSDOM('<!doctype html><html><body></body></html>');
+const jsdom = new JSDOM('<!doctype html><html><body><div id="app"></div></body></html>');
 const { window } = jsdom;
 
 function copyProps(src, target) {

--- a/tests/src/ace.spec.js
+++ b/tests/src/ace.spec.js
@@ -324,14 +324,15 @@ describe('Ace Component', () => {
         }, 110);
       }, 50);
     });
-    it('should keep initial value after undo event', () => {
+    it('should keep initial value after undo event', (done) => {
       const onInput = () => {
         const editor = wrapper.instance().editor;
         editor.undo();
         expect(editor.getValue()).to.equal('foobar');
+        done();
       };
 
-      const wrapper = mount(<AceEditor value="foobar" onInput={onInput} />);
+      const wrapper = mount(<AceEditor value="foobar" onInput={onInput} />, mountOptions);
     });
   });
 
@@ -356,7 +357,7 @@ describe('Ace Component', () => {
     it('should limit call to onChange (debounce)', (done) => {
       const period = 100;
       const onChangeCallback = sinon.spy();
-      const wrapper = mount(<AceEditor onChange={onChangeCallback} debounceChangePeriod={period}/>);
+      const wrapper = mount(<AceEditor onChange={onChangeCallback} debounceChangePeriod={period}/>, mountOptions);
 
       // Check is not previously called
       expect(onChangeCallback.callCount).to.equal(0);

--- a/tests/src/ace.spec.js
+++ b/tests/src/ace.spec.js
@@ -1,10 +1,9 @@
 import { expect } from 'chai';
 import React from 'react';
 import sinon from 'sinon';
-import ace from 'brace';
+import ace from 'ace-builds';
 import Enzyme, { mount } from 'enzyme';
 import AceEditor from '../../src/ace.js';
-import brace from 'brace'; // eslint-disable-line no-unused-vars
 import Adapter from 'enzyme-adapter-react-16';
 
 Enzyme.configure({ adapter: new Adapter() });

--- a/tests/src/ace.spec.js
+++ b/tests/src/ace.spec.js
@@ -585,13 +585,13 @@ describe('Ace Component', () => {
 
       // Read set value
       let editor = wrapper.instance().refEditor;
-      expect(editor.className).to.equal(' ace_editor ace-tm old-class');
+      expect(editor.className).to.equal(' ace_editor ace_hidpi ace-tm old-class');
 
       // Now trigger the componentDidUpdate
       const newClassName = 'new-class';
       wrapper.setProps({className: newClassName});
       editor = wrapper.instance().refEditor;
-      expect(editor.className).to.equal(' new-class ace_editor ace-tm');
+      expect(editor.className).to.equal(' new-class ace_editor ace_hidpi ace-tm');
     });
 
 

--- a/tests/src/ace.spec.js
+++ b/tests/src/ace.spec.js
@@ -331,7 +331,7 @@ describe('Ace Component', () => {
         expect(editor.getValue()).to.equal('foobar');
       };
 
-      const wrapper = mount(<AceEditor value="foobar" onInput={onInput} />, mountOptions);
+      const wrapper = mount(<AceEditor value="foobar" onInput={onInput} />);
     });
   });
 
@@ -356,7 +356,7 @@ describe('Ace Component', () => {
     it('should limit call to onChange (debounce)', (done) => {
       const period = 100;
       const onChangeCallback = sinon.spy();
-      const wrapper = mount(<AceEditor onChange={onChangeCallback} debounceChangePeriod={period}/>, mountOptions);
+      const wrapper = mount(<AceEditor onChange={onChangeCallback} debounceChangePeriod={period}/>);
 
       // Check is not previously called
       expect(onChangeCallback.callCount).to.equal(0);

--- a/tests/src/split.spec.js
+++ b/tests/src/split.spec.js
@@ -213,7 +213,7 @@ describe('Split Component', () => {
 
     it('should call the onSelectionChange method callback', () => {
       const onSelectionChangeCallback = sinon.spy();
-      const wrapper = mount(<SplitEditor onSelectionChange={onSelectionChangeCallback} value="some value"/>, mountOptions);
+      const wrapper = mount(<SplitEditor onSelectionChange={onSelectionChangeCallback} value="some value" />, mountOptions);
 
       // Check is not previously called
       expect(onSelectionChangeCallback.callCount).to.equal(0);

--- a/tests/src/split.spec.js
+++ b/tests/src/split.spec.js
@@ -383,7 +383,7 @@ describe('Split Component', () => {
       expect(editor.getValue()).to.equal(newValue);
       expect(editor2.getValue()).to.equal(anotherNewValue);
     });
-   it('should set up the markers', () => {
+    it('should set up the markers', () => {
       const markers = [[{
         startRow: 3,
         type: 'text',
@@ -433,7 +433,7 @@ describe('Split Component', () => {
       expect(editorB.getSession().getMarkers()['6'].type).to.equal('text');
     });
 
-  it('should update the markers', () => {
+   it('should update the markers', () => {
       const oldMarkers = [[
         {
           startRow: 4,

--- a/tests/src/split.spec.js
+++ b/tests/src/split.spec.js
@@ -352,13 +352,13 @@ describe('Split Component', () => {
 
       // Read set value
       let editor = wrapper.instance().refEditor;
-      expect(editor.className).to.equal(' ace_editor ace-tm old-class');
+      expect(editor.className).to.equal(' ace_editor ace_hidpi ace-tm old-class');
 
       // Now trigger the componentDidUpdate
       const newClassName = 'new-class';
       wrapper.setProps({className: newClassName});
       editor = wrapper.instance().refEditor;
-      expect(editor.className).to.equal(' new-class ace_editor ace-tm');
+      expect(editor.className).to.equal(' new-class ace_editor ace_hidpi ace-tm');
     });
 
 

--- a/tests/src/split.spec.js
+++ b/tests/src/split.spec.js
@@ -1,10 +1,9 @@
 import { expect } from 'chai';
 import React from 'react';
 import sinon from 'sinon';
-import ace from 'brace';
+import ace from 'ace-builds';
 import Enzyme, { mount } from 'enzyme';
 import SplitEditor from '../../src/split.js';
-import brace from 'brace'; // eslint-disable-line no-unused-vars
 import Adapter from 'enzyme-adapter-react-16';
 
 Enzyme.configure({ adapter: new Adapter() });

--- a/webpack.config.example.js
+++ b/webpack.config.example.js
@@ -33,5 +33,5 @@ module.exports = {
     contentBase:  [path.join(__dirname, 'example'), path.join(__dirname, 'dist')],
     compress: true,
     port: 9000,
-  },
+  }
 };


### PR DESCRIPTION
# What's in this PR?
Currently, `react-ace` is using `brace` for bundling the underlying ace editor's files. `brace` unfortunately is several versions behind the official release. Therefore this PR is moving from `brace` to the official `ace-builds` distribution.

## List the changes you made and your reasons for them.

* Replacing `brace` package with `ace-builds` and adapting imports accordingly
* Adapting tests to newly added css classes

## References

### Fixes #
Fixes #512.
### Progress on: #