### PR TITLE
WIP: focus editor after resize in componentDidMount

### DIFF
--- a/src/ace.js
+++ b/src/ace.js
@@ -111,15 +111,15 @@ export default class ReactAce extends Component {
       this.refEditor.className += ' ' + className;
     }
 
-    if (focus) {
-      this.editor.focus();
-    }
-
     if (onLoad) {
       onLoad(this.editor);
     }
 
     this.editor.resize();
+
+    if (focus) {
+      this.editor.focus();
+    }
   }
 
   componentDidUpdate(prevProps) {


### PR DESCRIPTION
# What's in this PR?

Move `editor.focus` after `editor.resize` in `componentDidMount`

## List the changes you made and your reasons for them.

Move `editor.focus` after `editor.resize` in `componentDidMount`.

The editor has a significant/visible delay in showing the content in some, but not all cases. The editor shows up empty first and then expands. In my case the editor has a border, which makes it look worse. Before it expands, it just shows a thick black line.

This change fixes that. I have yet to reduce my case to a minimal demo but I'll probably do that in the next few days.  This problem may have something to do with the order of position calculating & style changes in the implementation of `editor.resize` and `editor.focus`.

And it does make some sense to focus the editor **after** it's resized. Currently in `componentDidUpdate`, `editor.focus` is replaced after `editor.resize`. 

## References

### Fixes #

### Progress on: #