### PR TITLE
prop-types : allow setting maxLines to 'Infinity'

### DIFF
--- a/src/ace.js
+++ b/src/ace.js
@@ -331,7 +331,7 @@ ReactAce.propTypes = {
   onBeforeLoad: PropTypes.func,
   onValidate: PropTypes.func,
   minLines: PropTypes.number,
-  maxLines: PropTypes.number,
+  maxLines: PropTypes.oneOfType([PropTypes.number, PropTypes.oneOf(['Infinity'])]),
   readOnly: PropTypes.bool,
   highlightActiveLine: PropTypes.bool,
   tabSize: PropTypes.number,


### PR DESCRIPTION
# What's in this PR?

Currently, `react-ace` throws a failed prop type warning when setting `maxLines` to `"Infinity"` which is a valid prop type, making the editor container fitting to its value and disabling vertical scroll.
This PR just fixes this warning allowing `"Infinity"` prop type.

## List the changes you made and your reasons for them.
- added `"Infinity"` to `maxLines` allowed prop types

## References

### Fixes #
closes #415

### Progress on: #