### PR TITLE
In type definitions, move debounceChangePeriod from AceOptions to com…

### DIFF
--- a/types.d.ts
+++ b/types.d.ts
@@ -91,7 +91,6 @@ export interface AceOptions {
     enableSnippets?: boolean
     spellcheck?: boolean
     useElasticTabstops?: boolean
-    debounceChangePeriod?: number
 }
 
 export interface EditorProps {
@@ -166,6 +165,7 @@ export interface AceEditorProps {
     annotations?: Array<Annotation>
     markers?: Array<Marker>
     style?: CSSProperties
+    debounceChangePeriod?: number
 }
 
 export default class AceEditor extends Component<AceEditorProps, {}> {}


### PR DESCRIPTION
Hi! Should be a quick one :). 

Doesn't look like you have any tests surrounding the type definitions (e.g. a `dtslint` step), but let me know if there's anything I need to do for testing. I've manually confirmed these changes make the TypeScript compiler happy in my own personal project I'm using this for.

# What's in this PR?

## List the changes you made and your reasons for them.

According to the [API docs](https://github.com/securingsincity/react-ace/blob/master/docs/Ace.md), the `debounceChangePeriod` option is supposed to be set on the top-level `<AceEditor>` component. However, the TS type definitions list it as part of the `AceOptions` object you can pass in via the `setOptions` prop.

In practice, the docs are correct and the types are wrong. The following functions as expected (fires `onChange` only after a 1000ms debounce period):

```js
<AceEditor debounceChangePeriod={1000} ... />
```

Conversely, the following does nothing:

```js
<AceEditor setOptions={{debounceChangePeriod: 1000}} ... />`
```

### Fixes #

I just moved the definition for the `debounceChangePeriod` parameter from the `AceOptions` object to the editor props.