### PR TITLE
Included onCursorChange to types.

### DIFF
--- a/types.d.ts
+++ b/types.d.ts
@@ -31,6 +31,10 @@ export interface Command {
     exec(editor: any): void
 }
 
+export interface Selection {
+  getCursor(): Annotation;
+}
+
 /**
  * See https://github.com/ajaxorg/ace/wiki/Configuring-Ace
  */
@@ -158,6 +162,7 @@ export interface AceEditorProps {
     onBlur?: (event: any) => void
     onValidate?: (annotations: Array<Annotation>) => void
     onScroll?: (editor: EditorProps) => void
+    onCursorChange?: (selection: Selection) => void;
     editorProps?: EditorProps
     setOptions?: AceOptions
     keyboardHandler?: string

--- a/types.d.ts
+++ b/types.d.ts
@@ -32,7 +32,7 @@ export interface Command {
 }
 
 export interface Selection {
-  getCursor(): Annotation;
+    getCursor(): Annotation;
 }
 
 /**


### PR DESCRIPTION
# What's in this PR?
Inclusion of `onCursorChange` to types
## List the changes you made and your reasons for them.
Typescript error when using `onCursorChange` on local project.
## References

### Fixes #

### Progress on: #