### PR TITLE
Added optional prop to disable navigating to end of file

### DIFF
--- a/src/ace.js
+++ b/src/ace.js
@@ -56,7 +56,9 @@ export default class ReactAce extends Component {
     this.editor.setTheme(`ace/theme/${theme}`);
     this.editor.setFontSize(fontSize);
     this.editor.getSession().setValue(!defaultValue ? value : defaultValue, cursorStart);
-    this.editor.navigateFileEnd();
+    if (this.props.navigateToFileEnd) {
+      this.editor.navigateFileEnd();
+    }
     this.editor.renderer.setShowGutter(showGutter);
     this.editor.getSession().setUseWrapMode(wrapEnabled);
     this.editor.setShowPrintMargin(showPrintMargin);
@@ -348,6 +350,7 @@ ReactAce.propTypes = {
   wrapEnabled: PropTypes.bool,
   enableBasicAutocompletion: PropTypes.oneOfType([PropTypes.bool, PropTypes.array]),
   enableLiveAutocompletion: PropTypes.oneOfType([PropTypes.bool, PropTypes.array]),
+  navigateToFileEnd: PropTypes.bool,
   commands: PropTypes.array,
 };
 
@@ -379,4 +382,5 @@ ReactAce.defaultProps = {
   wrapEnabled: false,
   enableBasicAutocompletion: false,
   enableLiveAutocompletion: false,
+  navigateToFileEnd: true,
 };


### PR DESCRIPTION
# What's in this PR?
Add option to disable navigating to end of file on mount

## List the changes you made and your reasons for them.
* Added a boolean `navigateToFileEnd` property on the `AceEditor` component
* Users might not want the default behaviour (I certainly don't want it) - will be good to have that configurable