### PR TITLE
Do not clear active line and active word markers

### DIFF
--- a/src/ace.js
+++ b/src/ace.js
@@ -281,10 +281,14 @@ export default class ReactAce extends Component {
         this.editor.getSession().removeMarker(currentMarkers[i].id);
       }
     }
-    // remove background markers
+    // remove background markers except active line marker and selected word marker
     currentMarkers = this.editor.getSession().getMarkers(false);
     for (const i in currentMarkers) {
-      if (currentMarkers.hasOwnProperty(i)) {
+      if (
+        currentMarkers.hasOwnProperty(i) &&
+        currentMarkers[i].clazz !== "ace_active-line" &&
+        currentMarkers[i].clazz !== "ace_selected-word"
+      ) {
         this.editor.getSession().removeMarker(currentMarkers[i].id);
       }
     }

--- a/tests/src/ace.spec.js
+++ b/tests/src/ace.spec.js
@@ -203,12 +203,40 @@ describe('Ace Component', () => {
 
       // Read the markers
       const editor = wrapper.instance().editor;
+      expect(Object.keys(editor.getSession().getMarkers())).to.deep.equal(['1', '2', '3']);
       expect(editor.getSession().getMarkers()['3'].clazz).to.equal('test-marker-old');
       expect(editor.getSession().getMarkers()['3'].type).to.equal('text');
       wrapper.setProps({markers});
       const editorB = wrapper.instance().editor;
 
-      expect(editorB.getSession().getMarkers()).to.deep.equal({})
+      expect(Object.keys(editorB.getSession().getMarkers())).to.deep.equal(['1', '2']);
+    });
+
+    it('should not remove active line and selected word highlight when clearing markers', () => {
+      const newMarkers = [
+        {
+          startRow: 4,
+          type: 'text',
+          className: 'test-marker'
+        }
+      ];
+      const wrapper = mount(
+        <AceEditor highlightActiveLine markers={[]} />,
+        mountOptions
+      );
+
+      const editor = wrapper.instance().editor;
+      const bgMarkers = editor.getSession().getMarkers(false);
+      expect(Object.keys(bgMarkers)).to.deep.equal(['1', '2']);
+      expect(bgMarkers['1']).to.have.property('clazz', 'ace_active-line');
+      expect(bgMarkers['2']).to.have.property('clazz', 'ace_selected-word');
+
+      wrapper.setProps({ markers: newMarkers });
+      const bgMarkersNew = editor.getSession().getMarkers(false);
+      expect(Object.keys(bgMarkersNew)).to.deep.equal(['1', '2', '3']);
+      expect(bgMarkersNew['1']).to.have.property('clazz', 'ace_active-line');
+      expect(bgMarkersNew['2']).to.have.property('clazz', 'ace_selected-word');
+      expect(bgMarkersNew['3']).to.have.property('clazz', 'test-marker');
     });
 
     it('should add annotations and clear them', () => {


### PR DESCRIPTION
# What's in this PR?

Changes the logic in `handleMarkers` to exclude the special markers for active line and selected word.

## List the changes you made and your reasons for them.

* Added check that current marker does not have special class name `ace_active-line` or `ace_selected-word` before clearing it.
* Added new test to verify new behaviour.
* Changed test "should clear the markers" to reflect that not all markers should be cleared anymore.

## References

### Fixes #

Fixes #190.

### Progress on: #