### PR TITLE
Mark `style` prop as optional and modify the type to more accurate for React Components.

### DIFF
--- a/src/ace.tsx
+++ b/src/ace.tsx
@@ -19,7 +19,7 @@ import { IAceOptions, ICommand, IEditorProps, IMarker } from "./types";
 
 export interface IAceEditorProps {
   name?: string;
-  style: any;
+  style?: React.CSSProperties;
   /** For available modes see https://github.com/thlorenz/brace/tree/master/mode */
   mode?: string;
   /** For available themes see https://github.com/thlorenz/brace/tree/master/theme */


### PR DESCRIPTION
# What's in this PR?
Correctly marks the `style` prop as optional since it has a default prop defined. Also updates it's type to be of `React.CSSProperties` since that's what it's getting used as once it's passed into the root `div`.

## List the changes you made and your reasons for them.
- Add optional operator to the `style` prop.
 - This prop has a default prop so it should not be marked as required in the props interface.

- Convert the type of `style` from `any` to `React.CSSProperties`
 - This is the type which is expected in the `style` prop of all react elements.

### Fixes #650 