### PR TITLE
Export typescript definitions from `./ace`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+export * from './ace';
 import ace from "./ace";
 import diff from "./diff";
 import split from "./split";


### PR DESCRIPTION
# What's in this PR?

exports IAceEditorProps

## List the changes you made and your reasons for them.

This allows to write:

```typesctipt
import { IAceEditorProps } from 'react-ace';
```


Make sure any changes to code include changes to documentation.

### Fixes  #655
