### PR TITLE
Fix theme not set properly for split editor

### DIFF
--- a/src/split.tsx
+++ b/src/split.tsx
@@ -201,6 +201,7 @@ export default class SplitComponent extends React.Component<
     } = this.props;
 
     this.editor = ace.edit(this.refEditor);
+    this.editor.setTheme(`ace/theme/${theme}`);
 
     if (onBeforeLoad) {
       onBeforeLoad(ace);


### PR DESCRIPTION
# What's in this PR?
This PR provides a fix for the split editor not having the properly-specified theme.

## List the changes you made and your reasons for them.
The general editor around the split, subeditors did not have a set theme, so it would use the default.  As a result, this caused its subeditors to follow the same theme, overwriting whatever theme was set for the split editors.  This includes a line to set the parent editor to the same theme.

I've tested this to make sure it works as expected.

## References

### Fixes #337.