### PR TITLE
Fix prettier configuration.

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "scripts": {
-    "prettier": "prettier --print-width 120 --single-quote --trailing-comma all   --write \"src/**\" \"example/*.js\"",
+    "prettier": "prettier --write \"src/**\" \"example/*.js\"",
     "clean": "rimraf lib dist",
     "lint": "tslint src/*",
     "build:lib": "tsc",
@@ -113,5 +113,9 @@
   "repository": {
     "type": "git",
     "url": "http://github.com/securingsincity/react-ace.git"
+  },
+  "prettier": {
+    "singleQuote": false,
+    "trailingComma": "none"
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -76,7 +76,7 @@ export interface IAceOptions {
   showInvisibles?: boolean;
   showPrintMargin?: boolean;
   printMarginColumn?: number;
-  printMargin?: boolean|number;
+  printMargin?: boolean | number;
   fadeFoldWidgets?: boolean;
   showFoldWidgets?: boolean;
   showLineNumbers?: boolean;


### PR DESCRIPTION
The current prettier configuration is not consistent with the formatting
used throughout the project. As a result, running the formatter on a
fresh repository results in a large number of spurious formatting
changes. This commit adjust the formatting rules to the point where
running the formatter only results in a single small change to
src/types.ts, which is also included in the commit.

In addition, because the formatting options are passed on the command
line through npm run, this prevents tools like VSCode from understanding
the project formatting guidelines. Moving the prettier configuration
into package.json enables integration with third-party tools.

# What's in this PR?

Changes to package.json to move the prettier configuration from command line options to part of package.json itself, as well as adjustments to the shipped configuration to make it consistent with the formatting used throughout the project. One tiny fix to src/types.ts that results from running the formatter is also included.

## List the changes you made and your reasons for them.

Please see the commit message. Trying to contribute to this project is complicated by the fact that adding a few lines to one file and the running the formatter results in changes to many project files, bloating potential PRs.