### PR TITLE
Enable Simple SSR

### DIFF
--- a/src/editorOptions.ts
+++ b/src/editorOptions.ts
@@ -45,10 +45,26 @@ const editorEvents: EditorEvent[] = [
   "handleOptions",
   "updateRef"
 ];
+// Typescript globals definition to allow us to create a window object during SSR.
+declare global {
+  namespace NodeJS {
+    interface Global {
+      window: any;
+    }
+  }
+}
 const getAceInstance = () => {
   let ace;
-  // Fallback for ace.require when vanilla ACE is hosted over a CDN
-  if ((window as any).ace) {
+  if (typeof window === "undefined") {
+    // ace-builds just needs some window object to attach ace to.
+    // During SSR even just an empty object will work.
+    global.window = {};
+    ace = require("ace-builds");
+    // And it can be discarded immediately afterward to avoid confusing
+    // other libraries that might detect SSR the same way we did.
+    delete global.window;
+  } else if ((window as any).ace) {
+    // Fallback for ace.require when vanilla ACE is hosted over a CDN
     ace = (window as any).ace;
     ace.acequire = (window as any).ace.require || (window as any).ace.acequire;
   } else {


### PR DESCRIPTION
# What's in this PR?

`react-ace` is almost SSR ready. The main render function merely inserts an empty div, which is then populated by ace in `componentDidMount`. Because `componentDidMount` is not fired during SSR, SSR should result in an empty div. Ideally we would start with the content that would be present after the initial call to `editor.resize()`, but an empty div is better than failing.

## List the changes you made and your reasons for them.

Currently `react-ace` fails during SSR because `require("ace-builds")` fails. ace-builds expects window to exist, but only to attach a global ace object to. react-ace doesn't actually use that global ace instance, rather it uses the handle to ace returned by require. And, again,
because all of the work is done in `componentDidMount`, just not failing during SSR doesn't require mocking up much of any kind of realistic window object like `jsdom` might try to do. It turns out that a simple empty object suffices.

Essentially here's what currently happens:

```js
// Blows up during SSR since window is not defined
if ((window as any).ace) {
```

So let's add an SSR check:

```js
if (typeof window === "undefined") {
  // Now this blows up because it wants to set window.ace to the ace instance
  ace = require("ace-builds");
```

So instead we can simply do this:

```js
if (typeof window === "undefined") {
  global.window = {}
  ace = require("ace-builds");
  delete global.window;
```

And all is right with the world.

While this may seem like a trivial change, currently `react-ace` cannot be used out of the box with tools like Gatsby that do SSR for production builds. Workarounds exist using libraries like `@loadable/component`, but why bother with another dependency when the solution is fairly simple?

FWIW I have a minimal working Gatsby example that I can also add if its helpful. I'm also working on more complete SSR support using `jsdom`, but that will represent a more complex PR so I thought I'd file the simple one first.