### PR TITLE
Remove default value for value prop, allowing use as an uncontrolled component

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,6 +116,7 @@
   },
   "prettier": {
     "singleQuote": false,
-    "trailingComma": "none"
+    "trailingComma": "none",
+    "arrowParens": "avoid"
   }
 }

--- a/src/ace.tsx
+++ b/src/ace.tsx
@@ -135,7 +135,6 @@ export default class ReactAce extends React.Component<IAceEditorProps> {
     theme: "",
     height: "500px",
     width: "500px",
-    value: "",
     fontSize: 12,
     enableSnippets: false,
     showGutter: true,
@@ -223,7 +222,9 @@ export default class ReactAce extends React.Component<IAceEditorProps> {
     this.editor.setFontSize(
       typeof fontSize === "number" ? `${fontSize}px` : fontSize
     );
-    this.editor.getSession().setValue(!defaultValue ? value : defaultValue);
+    this.editor
+      .getSession()
+      .setValue(!defaultValue ? value && "" : defaultValue);
 
     if (this.props.navigateToFileEnd) {
       this.editor.navigateFileEnd();
@@ -327,7 +328,11 @@ export default class ReactAce extends React.Component<IAceEditorProps> {
     }
 
     // First process editor value, as it may create a new session (see issue #300)
-    if (this.editor && this.editor.getValue() !== nextProps.value) {
+    if (
+      this.editor &&
+      nextProps.value &&
+      this.editor.getValue() !== nextProps.value
+    ) {
       // editor.setValue is a synchronous function call, change event is emitted before setValue return.
       this.silent = true;
       const pos = this.editor.session.selection.toJSON();


### PR DESCRIPTION
# What's in this PR?

A fix to allow AceEditor to operate as an uncontrolled component.

## List the changes you made and your reasons for them.

I removed the default "" (empty string) value for the value prop. The problem is that, this default value ends up being passed to componentDidUpdate, overwriting whatever was in the buffer at that point. This forces a user of AceEditor to wrap it in a component that preserves the state across props changes—the controlled component pattern. This works fine, but it's not necessary. Removing the "" default and checking for undefined when updating props allows the component to work in an uncontrolled fashion, simplifying integration with other React components.

> Make sure any changes to code include changes to documentation.

Yeah, I didn't do this yet. I've seen some discussion previously in the issues regarding this behavior of ReactAce, so on some level I think that this is a bug fix. However, it does somewhat change the behavior of the component so it probably should be documented. Note, however, that any wrappers that were already passing in value manually should continue to work just fine.