### PR TITLE
Add prepare script to enable GitHub install.

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "postversion": "git push && git push --tags && npm run clean",
     "prepublishOnly": "npm run clean && npm run build",
     "test": "mocha --require ts-node/register --require @babel/register --require tests/setup.js tests/src/*.spec.js --exit",
-    "coverage": "nyc npm run test"
+    "coverage": "nyc npm run test",
+    "prepare": "npm run build:lib"
   },
   "author": "James Hrisho",
   "license": "MIT",


### PR DESCRIPTION
A prepare script will ensure that the devDependencies are installed and the build command is run after an install from GitHub.