### PR TITLE
Fix prettier configuration (again).

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,6 +116,7 @@
   },
   "prettier": {
     "singleQuote": false,
-    "trailingComma": "none"
+    "trailingComma": "none",
+    "arrowParens": "avoid"
   }
 }


### PR DESCRIPTION
Add arrowParens: avoid to the prettier configuration to avoid reformatting files on initial clone. This will help keep PRs compact.