### PR TITLE
fix typescript binding for ICommand.exec()

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -57,7 +57,7 @@ export interface ICommandBindKey {
 export interface ICommand {
   name: string;
   bindKey: ICommandBindKey;
-  exec(): any;
+  exec(editor: Ace.Editor, args?: any): any;
 }
 export interface IAceOptions {
   [index: string]: any;


### PR DESCRIPTION
This callback always has editor passed as first argument and optionally has args passes as second argument as can be seen in https://github.com/ajaxorg/ace/blob/master/lib/ace/commands/default_commands.js.
