### PR TITLE
fix no ace_editor.css in shadow dom

### DIFF
--- a/src/ace.tsx
+++ b/src/ace.tsx
@@ -167,12 +167,21 @@ export default class ReactAce extends React.Component<IAceEditorProps> {
   public silent: boolean;
   constructor(props: IAceEditorProps) {
     super(props);
-    editorEvents.forEach(method => {
+    editorEvents.forEach((method) => {
       this[method] = this[method].bind(this);
     });
     this.debounce = debounce;
   }
-
+  public isInShadow(node: HTMLElement): boolean {
+    let parent = node && node.parentNode;
+    while (parent) {
+      if (parent.toString() === "[object ShadowRoot]") {
+        return true;
+      }
+      parent = parent.parentNode;
+    }
+    return false;
+  }
   public componentDidMount() {
     const {
       className,
@@ -218,6 +227,9 @@ export default class ReactAce extends React.Component<IAceEditorProps> {
       scrollMargin[2],
       scrollMargin[3]
     );
+    if (this.isInShadow(this.refEditor)) {
+      this.editor.renderer.attachToShadowRoot();
+    }
     this.editor.getSession().setMode(`ace/mode/${mode}`);
     this.editor.setTheme(`ace/theme/${theme}`);
     this.editor.setFontSize(
@@ -260,7 +272,7 @@ export default class ReactAce extends React.Component<IAceEditorProps> {
 
     // get a list of possible options to avoid 'misspelled option errors'
     const availableOptions = this.editor.$options;
-    editorOptions.forEach(option => {
+    editorOptions.forEach((option) => {
       if (availableOptions.hasOwnProperty(option)) {
         // @ts-ignore
         this.editor.setOption(option, this.props[option]);
@@ -274,7 +286,7 @@ export default class ReactAce extends React.Component<IAceEditorProps> {
     this.handleOptions(this.props);
 
     if (Array.isArray(commands)) {
-      commands.forEach(command => {
+      commands.forEach((command) => {
         if (typeof command.exec === "string") {
           this.editor.commands.bindKey(command.bindKey, command.exec);
         } else {
@@ -318,7 +330,7 @@ export default class ReactAce extends React.Component<IAceEditorProps> {
       const appliedClasses = this.refEditor.className;
       const appliedClassesArray = appliedClasses.trim().split(" ");
       const oldClassesArray = oldProps.className.trim().split(" ");
-      oldClassesArray.forEach(oldClass => {
+      oldClassesArray.forEach((oldClass) => {
         const index = appliedClassesArray.indexOf(oldClass);
         appliedClassesArray.splice(index, 1);
       });

--- a/src/split.tsx
+++ b/src/split.tsx
@@ -171,12 +171,21 @@ export default class SplitComponent extends React.Component<
   public debounce: (fn: any, delay: number) => (...args: any) => void;
   constructor(props: ISplitEditorProps) {
     super(props);
-    editorEvents.forEach(method => {
+    editorEvents.forEach((method) => {
       this[method] = this[method].bind(this);
     });
     this.debounce = debounce;
   }
-
+  public isInShadow(node: HTMLElement): boolean {
+    let parent = node && node.parentNode;
+    while (parent) {
+      if (parent.toString() === "[object ShadowRoot]") {
+        return true;
+      }
+      parent = parent.parentNode;
+    }
+    return false;
+  }
   public componentDidMount() {
     const {
       className,
@@ -201,6 +210,9 @@ export default class SplitComponent extends React.Component<
     } = this.props;
 
     this.editor = ace.edit(this.refEditor);
+    if (this.isInShadow(this.refEditor)) {
+      this.editor.renderer.attachToShadowRoot();
+    }
     this.editor.setTheme(`ace/theme/${theme}`);
 
     if (onBeforeLoad) {
@@ -285,7 +297,7 @@ export default class SplitComponent extends React.Component<
       this.handleOptions(this.props, editor);
 
       if (Array.isArray(commands)) {
-        commands.forEach(command => {
+        commands.forEach((command) => {
           if (typeof command.exec === "string") {
             (editor.commands as any).bindKey(command.bindKey, command.exec);
           } else {
@@ -394,7 +406,7 @@ export default class SplitComponent extends React.Component<
       const appliedClasses = this.refEditor.className;
       const appliedClassesArray = appliedClasses.trim().split(" ");
       const oldClassesArray = oldProps.className.trim().split(" ");
-      oldClassesArray.forEach(oldClass => {
+      oldClassesArray.forEach((oldClass) => {
         const index = appliedClassesArray.indexOf(oldClass);
         appliedClassesArray.splice(index, 1);
       });


### PR DESCRIPTION
When I add `AceEditor` in shadow dom, there is no `ace_editor.css` in `#shadow-root`, which makes `AceEditor` looks messy.