### PR TITLE
Allow Editor to be reset to empty value by passing an empty value.

### DIFF
--- a/src/ace.tsx
+++ b/src/ace.tsx
@@ -342,7 +342,7 @@ export default class ReactAce extends React.Component<IAceEditorProps> {
     // First process editor value, as it may create a new session (see issue #300)
     if (
       this.editor &&
-      nextProps.value !== undefined &&
+      nextProps.value != null &&
       this.editor.getValue() !== nextProps.value
     ) {
       // editor.setValue is a synchronous function call, change event is emitted before setValue return.

--- a/src/ace.tsx
+++ b/src/ace.tsx
@@ -341,7 +341,9 @@ export default class ReactAce extends React.Component<IAceEditorProps> {
 
     // First process editor value, as it may create a new session (see issue #300)
     if (
-      this.editor && this.editor.getValue() !== nextProps.value
+      this.editor &&
+      nextProps.value !== undefined &&
+      this.editor.getValue() !== nextProps.value
     ) {
       // editor.setValue is a synchronous function call, change event is emitted before setValue return.
       this.silent = true;

--- a/src/ace.tsx
+++ b/src/ace.tsx
@@ -341,9 +341,7 @@ export default class ReactAce extends React.Component<IAceEditorProps> {
 
     // First process editor value, as it may create a new session (see issue #300)
     if (
-      this.editor &&
-      nextProps.value &&
-      this.editor.getValue() !== nextProps.value
+      this.editor && this.editor.getValue() !== nextProps.value
     ) {
       // editor.setValue is a synchronous function call, change event is emitted before setValue return.
       this.silent = true;


### PR DESCRIPTION

# What's in this PR?

Allow editor to be reset to empty value by passing an empty value.


## List the changes you made and your reasons for them.

Removed check if next props are empty before setting the new value.

## References

https://github.com/securingsincity/react-ace/issues/894

### Fixes #

Closes #894
