### PR TITLE
Import Range from ace-builds in ace.tsx to match split.tsx

### DIFF
--- a/src/ace.tsx
+++ b/src/ace.tsx
@@ -1,4 +1,4 @@
-import { Ace } from "ace-builds";
+import { Ace, Range } from "ace-builds";
 import * as AceBuilds from "ace-builds";
 import * as PropTypes from "prop-types";
 import * as React from "react";
@@ -10,7 +10,6 @@ import {
   getAceInstance
 } from "./editorOptions";
 const ace = getAceInstance();
-const { Range } = ace.require("ace/range");
 
 import {
   IAceEditor,


### PR DESCRIPTION
# What's in this PR?

Import Range from `ace-builds` in ace.tsx instead of relying on `EditorOptions.getAceInstance`.

## List the changes you made and your reasons for them.


Attempting to use `react-ace` to import `Range` when `window.ace` is defined results in the Range package not being found.

I don't see any reason why not to import Range directly from `ace-builds`, since that's already the approach taken in `split.tsx`


## References
Related issue that this PR is intended to address: https://github.com/securingsincity/react-ace/issues/954
### Fixes #

### Progress on: #