### PR TITLE
Fix type for exec param in ICommand interface

### DIFF
--- a/src/ace.tsx
+++ b/src/ace.tsx
@@ -289,9 +289,9 @@ export default class ReactAce extends React.Component<IAceEditorProps> {
     if (Array.isArray(commands)) {
       commands.forEach((command) => {
         if (typeof command.exec === "string") {
-          this.editor.commands.bindKey(command.bindKey, command.exec);
+          (this.editor.commands as any).bindKey(command.bindKey, command.exec);
         } else {
-          this.editor.commands.addCommand(command);
+          (this.editor.commands as any).addCommand(command);
         }
       });
     }

--- a/src/split.tsx
+++ b/src/split.tsx
@@ -301,7 +301,7 @@ export default class SplitComponent extends React.Component<
           if (typeof command.exec === "string") {
             (editor.commands as any).bindKey(command.bindKey, command.exec);
           } else {
-            editor.commands.addCommand(command);
+            (editor.commands as any).addCommand(command);
           }
         });
       }

--- a/src/types.ts
+++ b/src/types.ts
@@ -54,10 +54,12 @@ export interface ICommandBindKey {
   mac: string;
 }
 
+type ICommandExecFunction = (editor: Ace.Editor, args?: any) => any;
+
 export interface ICommand {
   name: string;
   bindKey: ICommandBindKey;
-  exec(editor: Ace.Editor, args?: any): any;
+  exec: string | ICommandExecFunction;
 }
 export interface IAceOptions {
   [index: string]: any;


### PR DESCRIPTION
# What's in this PR?
Fix type for exec param in ICommand interface

## List the changes you made and your reasons for them.

Type for ICommand exec param can be also a string according to FAQ example https://github.com/securingsincity/react-ace/blob/master/docs/FAQ.md#how-do-i-change-key-bindings-for-an-existing-command and  type checking in source code https://github.com/securingsincity/react-ace/blob/master/src/ace.tsx#L291