### PR TITLE
Accept an object as mode

### DIFF
--- a/src/ace.tsx
+++ b/src/ace.tsx
@@ -75,7 +75,7 @@ export interface IAceEditorProps {
 
 export default class ReactAce extends React.Component<IAceEditorProps> {
   public static propTypes: PropTypes.ValidationMap<IAceEditorProps> = {
-    mode: PropTypes.string,
+    mode: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
     focus: PropTypes.bool,
     theme: PropTypes.string,
     name: PropTypes.string,
@@ -165,7 +165,7 @@ export default class ReactAce extends React.Component<IAceEditorProps> {
   public silent: boolean;
   constructor(props: IAceEditorProps) {
     super(props);
-    editorEvents.forEach((method) => {
+    editorEvents.forEach(method => {
       this[method] = this[method].bind(this);
     });
     this.debounce = debounce;
@@ -228,7 +228,11 @@ export default class ReactAce extends React.Component<IAceEditorProps> {
     if (this.isInShadow(this.refEditor)) {
       this.editor.renderer.attachToShadowRoot();
     }
-    this.editor.getSession().setMode(`ace/mode/${mode}`);
+    this.editor
+      .getSession()
+      .setMode(
+        typeof mode === "string" ? `ace/mode/${mode}` : (mode as Ace.SyntaxMode)
+      );
     this.editor.setTheme(`ace/theme/${theme}`);
     this.editor.setFontSize(
       typeof fontSize === "number" ? `${fontSize}px` : fontSize
@@ -272,7 +276,7 @@ export default class ReactAce extends React.Component<IAceEditorProps> {
 
     // get a list of possible options to avoid 'misspelled option errors'
     const availableOptions = this.editor.$options;
-    editorOptions.forEach((option) => {
+    editorOptions.forEach(option => {
       if (availableOptions.hasOwnProperty(option)) {
         // @ts-ignore
         this.editor.setOption(option, this.props[option]);
@@ -286,7 +290,7 @@ export default class ReactAce extends React.Component<IAceEditorProps> {
     this.handleOptions(this.props);
 
     if (Array.isArray(commands)) {
-      commands.forEach((command) => {
+      commands.forEach(command => {
         if (typeof command.exec === "string") {
           (this.editor.commands as any).bindKey(command.bindKey, command.exec);
         } else {
@@ -330,7 +334,7 @@ export default class ReactAce extends React.Component<IAceEditorProps> {
       const appliedClasses = this.refEditor.className;
       const appliedClassesArray = appliedClasses.trim().split(" ");
       const oldClassesArray = oldProps.className.trim().split(" ");
-      oldClassesArray.forEach((oldClass) => {
+      oldClassesArray.forEach(oldClass => {
         const index = appliedClassesArray.indexOf(oldClass);
         appliedClassesArray.splice(index, 1);
       });
@@ -356,7 +360,13 @@ export default class ReactAce extends React.Component<IAceEditorProps> {
       this.updatePlaceholder();
     }
     if (nextProps.mode !== oldProps.mode) {
-      this.editor.getSession().setMode("ace/mode/" + nextProps.mode);
+      this.editor
+        .getSession()
+        .setMode(
+          typeof nextProps.mode === "string"
+            ? `ace/mode/${nextProps.mode}`
+            : (nextProps.mode as Ace.SyntaxMode)
+        );
     }
     if (nextProps.theme !== oldProps.theme) {
       this.editor.setTheme("ace/theme/" + nextProps.theme);

--- a/tests/src/ace.spec.js
+++ b/tests/src/ace.spec.js
@@ -358,12 +358,12 @@ describe("Ace Component", () => {
     it("function arg should be called when after timeout", done => {
       const wrapper = mount(<AceEditor />, mountOptions);
       var flag = false;
-      var func = wrapper.instance().debounce(function() {
+      var func = wrapper.instance().debounce(function () {
         flag = true;
       }, 100);
       func();
       expect(flag).to.be.false;
-      setTimeout(function() {
+      setTimeout(function () {
         expect(flag).to.be.true;
         done();
       }, 150);
@@ -373,19 +373,19 @@ describe("Ace Component", () => {
       const wrapper = mount(<AceEditor />, mountOptions);
 
       var flag = false;
-      var func = wrapper.instance().debounce(function() {
+      var func = wrapper.instance().debounce(function () {
         flag = true;
       }, 100);
       func();
       expect(flag).to.be.false;
-      setTimeout(function() {
+      setTimeout(function () {
         expect(flag).to.be.false;
         func();
       }, 50);
-      setTimeout(function() {
+      setTimeout(function () {
         expect(flag).to.be.false;
       }, 120);
-      setTimeout(function() {
+      setTimeout(function () {
         expect(flag).to.be.true;
         done();
       }, 160);
@@ -396,7 +396,7 @@ describe("Ace Component", () => {
 
       var flag1 = false;
       var flag2 = false;
-      var func = wrapper.instance().debounce(function() {
+      var func = wrapper.instance().debounce(function () {
         if (flag1) {
           flag2 = true;
         }
@@ -406,15 +406,15 @@ describe("Ace Component", () => {
       func();
       expect(flag1).to.be.false;
       expect(flag2).to.be.false;
-      setTimeout(function() {
+      setTimeout(function () {
         expect(flag1).to.be.false;
         expect(flag2).to.be.false;
         func();
-        setTimeout(function() {
+        setTimeout(function () {
           expect(flag1).to.be.true;
           expect(flag2).to.be.false;
           func();
-          setTimeout(function() {
+          setTimeout(function () {
             expect(flag1).to.be.true;
             expect(flag2).to.be.false;
             done();
@@ -475,7 +475,7 @@ describe("Ace Component", () => {
 
       expect(onChangeCallback.callCount).to.equal(0);
 
-      setTimeout(function() {
+      setTimeout(function () {
         expect(onChangeCallback.callCount).to.equal(1);
         expect(onChangeCallback.getCall(0).args[0]).to.equal(expectText2);
         expect(onChangeCallback.getCall(0).args[1].action).to.eq("insert");
@@ -483,7 +483,7 @@ describe("Ace Component", () => {
         wrapper.instance().editor.setValue(expectText2, 1);
         wrapper.instance().editor.setValue(expectText, 1);
         expect(onChangeCallback.callCount).to.equal(0);
-        setTimeout(function() {
+        setTimeout(function () {
           expect(onChangeCallback.callCount).to.equal(1);
           expect(onChangeCallback.getCall(0).args[0]).to.equal(expectText);
           expect(onChangeCallback.getCall(0).args[1].action).to.eq("insert");
@@ -546,7 +546,7 @@ describe("Ace Component", () => {
     });
 
     it("should call the onSelectionChange method callback", done => {
-      let onSelectionChange = function() {};
+      let onSelectionChange = function () {};
       const value = `
         function main(value) {
           console.log('hi james')
@@ -555,7 +555,7 @@ describe("Ace Component", () => {
       `;
       const wrapper = mount(<AceEditor value={value} />, mountOptions);
 
-      onSelectionChange = function(selection) {
+      onSelectionChange = function (selection) {
         const content = wrapper
           .instance()
           .editor.session.getTextRange(selection.getRange());
@@ -563,14 +563,11 @@ describe("Ace Component", () => {
         done();
       };
       wrapper.setProps({ onSelectionChange });
-      wrapper
-        .instance()
-        .editor.getSession()
-        .selection.selectAll();
+      wrapper.instance().editor.getSession().selection.selectAll();
     });
 
     it("should call the onCursorChange method callback", done => {
-      let onCursorChange = function() {};
+      let onCursorChange = function () {};
       const value = `
         function main(value) {
           console.log('hi james')
@@ -579,21 +576,15 @@ describe("Ace Component", () => {
       `;
 
       const wrapper = mount(<AceEditor value={value} />, mountOptions);
-      onCursorChange = function(selection) {
+      onCursorChange = function (selection) {
         expect(selection.getCursor()).to.deep.equal({ row: 0, column: 0 });
         done();
       };
       wrapper.setProps({ onCursorChange });
       expect(
-        wrapper
-          .instance()
-          .editor.getSession()
-          .selection.getCursor()
+        wrapper.instance().editor.getSession().selection.getCursor()
       ).to.deep.equal({ row: 5, column: 6 });
-      wrapper
-        .instance()
-        .editor.getSession()
-        .selection.moveCursorTo(0, 0);
+      wrapper.instance().editor.getSession().selection.moveCursorTo(0, 0);
     });
 
     it("should call the onBlur method callback", () => {
@@ -659,15 +650,29 @@ describe("Ace Component", () => {
       expect(editor.getOption("minLines")).to.equal(2);
     });
 
-    it("should update the mode on componentDidUpdate", () => {
-      const wrapper = mount(<AceEditor mode="javascript" />, mountOptions);
+    describe("mode prop", () => {
+      it("should update the mode on componentDidUpdate", () => {
+        const wrapper = mount(<AceEditor mode="javascript" />, mountOptions);
 
-      // Read set value
-      const oldMode = wrapper.first("AceEditor").props();
+        // Read set value
+        const oldMode = wrapper.first("AceEditor").props();
 
-      wrapper.setProps({ mode: "elixir" });
-      const newMode = wrapper.first("AceEditor").props();
-      expect(oldMode).to.not.deep.equal(newMode);
+        wrapper.setProps({ mode: "elixir" });
+        const newMode = wrapper.first("AceEditor").props();
+        expect(oldMode).to.not.deep.equal(newMode);
+      });
+
+      it("should accept an object mode", () => {
+        const wrapper = mount(<AceEditor />, mountOptions);
+        const session = wrapper.instance().editor.getSession();
+        const sessionSpy = sinon.spy(session, "setMode");
+
+        const mode = {
+          path: "ace/mode/javascript"
+        };
+        wrapper.setProps({ mode: mode });
+        expect(sessionSpy.withArgs(mode).callCount).to.equal(1);
+      });
     });
 
     it("should update many props on componentDidUpdate", () => {


### PR DESCRIPTION
# What's in this PR?

Accept mode as object or string

## List the changes you made and your reasons for them.
React-ace forces me to use a syntax mode defined in this namespace: "ace/mode/?" whereas Ace setMode can accept both strings and objects. It allows us to inject a custom Ace.SyntaxMode for example or use another defined in another namespace with:
```javascript
{ path: "path/to/mode" }
```

## References

[Ace repo](https://github.com/ajaxorg/ace#ace-ajaxorg-cloud9-editor):

```javascript
var JavaScriptMode = ace.require("ace/mode/javascript").Mode;
editor.session.setMode(new JavaScriptMode());
```
