### PR TITLE
Prevent no theme error

### DIFF
--- a/src/ace.tsx
+++ b/src/ace.tsx
@@ -233,7 +233,8 @@ export default class ReactAce extends React.Component<IAceEditorProps> {
       .setMode(
         typeof mode === "string" ? `ace/mode/${mode}` : (mode as Ace.SyntaxMode)
       );
-    this.editor.setTheme(`ace/theme/${theme}`);
+    if(theme && theme !== "")
+      this.editor.setTheme(`ace/theme/${theme}`);
     this.editor.setFontSize(
       typeof fontSize === "number" ? `${fontSize}px` : fontSize
     );


### PR DESCRIPTION
# What's in this PR?

Prevent the following error if theme property is empty or undefined

> index.js:1 Unable to infer path to ace from script src, use ace.config.set('basePath', 'path') to enable dynamic loading of modes and themes or with webpack use ace/webpack-resolver

## List the changes you made and your reasons for them.

test if theme property exists and is not empty before set editor option

## References

### Fixes #

### Progress on: #