### PR TITLE
Fix Uncaught TypeError: (reading 'destroy')

### DIFF
--- a/src/ace.tsx
+++ b/src/ace.tsx
@@ -436,8 +436,10 @@ export default class ReactAce extends React.Component<IAceEditorProps> {
   }
 
   public componentWillUnmount() {
-    this.editor.destroy();
-    this.editor = null;
+    if (this.editor) {
+      this.editor.destroy();
+      this.editor = null;
+    } 
   }
 
   public onChange(event: any) {


### PR DESCRIPTION
fix Uncaught TypeError: Cannot read properties of undefined (reading 'destroy')

# What's in this PR?
Fix this problem.
> Uncaught TypeError: Cannot read properties of undefined (reading 'destroy')

## List the changes you made and your reasons for them.

add guard  when componentWillUnmount trigger.

Make sure any changes to code include changes to documentation.

## References

### Fixes #

### Progress on: #