### PR TITLE
Fix changing value loses annotations

### DIFF
--- a/src/ace.tsx
+++ b/src/ace.tsx
@@ -344,11 +344,11 @@ export default class ReactAce extends React.Component<IAceEditorProps> {
     }
 
     // First process editor value, as it may create a new session (see issue #300)
-    if (
-      this.editor &&
+    const valueChanged = this.editor &&
       nextProps.value != null &&
-      this.editor.getValue() !== nextProps.value
-    ) {
+      this.editor.getValue() !== nextProps.value;
+
+    if (valueChanged) {
       // editor.setValue is a synchronous function call, change event is emitted before setValue return.
       this.silent = true;
       const pos = this.editor.session.selection.toJSON();
@@ -400,7 +400,9 @@ export default class ReactAce extends React.Component<IAceEditorProps> {
     if (!isEqual(nextProps.setOptions, oldProps.setOptions)) {
       this.handleOptions(nextProps);
     }
-    if (!isEqual(nextProps.annotations, oldProps.annotations)) {
+    // if the value or annotations changed, set the annotations
+    // changing the value may create create a new session which will require annotations to be re-set
+    if (valueChanged || !isEqual(nextProps.annotations, oldProps.annotations)) {
       this.editor.getSession().setAnnotations(nextProps.annotations || []);
     }
     if (

--- a/tests/src/ace.spec.js
+++ b/tests/src/ace.spec.js
@@ -343,6 +343,29 @@ describe("Ace Component", () => {
       );
     });
 
+    it("should keep annotations with changing editor value", () => {
+      // See https://github.com/securingsincity/react-ace/issues/300
+      const annotations = [
+        { row: 0, column: 0, text: "error.message", type: "error" }
+      ];
+      const initialText = `Initial
+      text`;
+      const modifiedText = `Modified
+      text`;
+      const wrapper = mount(
+        <AceEditor annotations={annotations} value={initialText} />,
+        mountOptions
+      );
+      const editor = wrapper.instance().editor;
+      wrapper.setProps({
+        value: modifiedText
+      });
+      expect(editor.renderer.$gutterLayer.$annotations).to.have.length(1);
+      expect(editor.renderer.$gutterLayer.$annotations[0]).to.have.property(
+        "className"
+      );
+    });
+
     it("should set editor to null on componentWillUnmount", () => {
       const wrapper = mount(<AceEditor />, mountOptions);
       expect(wrapper.getElement().editor).to.not.equal(null);


### PR DESCRIPTION
# What's in this PR?

## List the changes you made and your reasons for them.

- Fix `componentDidUpdate` to re-set the `this.editor.getSession().setAnnotations` if the `value` changes because changing value creates a new `session` which means the previous `annotations` are no longer rendered
- Added test for persisting annotations when updating `value` prop

## References

### Fixes https://github.com/securingsincity/react-ace/issues/1099

### Progress on: #