### PR TITLE
fix type annotation of newLineMode

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -103,7 +103,7 @@ export interface IAceOptions {
   tooltipFollowsMouse?: boolean;
   firstLineNumber?: number;
   overwrite?: boolean;
-  newLineMode?: boolean;
+  newLineMode?: "auto" | "unix" | "windows";
   useWorker?: boolean;
   useSoftTabs?: boolean;
   tabSize?: number;


### PR DESCRIPTION
# What's in this PR?

`newLineMode`  is not a boolean, update it according to https://github.com/ajaxorg/ace/wiki/Configuring-Ace#session-options