### PR TITLE
Fix foldstyle option

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -108,7 +108,7 @@ export interface IAceOptions {
   useSoftTabs?: boolean;
   tabSize?: number;
   wrap?: boolean;
-  foldStyle?: boolean;
+  foldStyle?: "markbegin" | "markbeginend" | "manual";
   /** path to a mode e.g "ace/mode/text" */
   mode?: string;
   /** on by default */

--- a/types.d.ts
+++ b/types.d.ts
@@ -84,7 +84,7 @@ export interface AceOptions {
     useSoftTabs?: boolean
     tabSize?: number
     wrap?: boolean
-    foldStyle?: boolean
+    foldStyle?: "markbegin"|"markbeginend"|"manual"
     /** path to a mode e.g "ace/mode/text" */
     mode?: string
     /** on by default */


### PR DESCRIPTION
Quick fix for `foldStyle` option in `IAceOptions`

Note: I checked to make sure there isnt some additional logic before this option is passed to `ace.editor.setOptions` that would justify it taking a `boolean` instead of what `setOptions` accepts for `foldStyle`  ( one of the following: `"markbegin" | "markbeginend" | "manual"` ).

Changes: 
- `foldStyle? boolean`  -> `foldStyle? "markbegin"|"markbeginend"|"manual"` in [react-ace/types.d.ts](https://github.com/bouzidanas/react-ace/blob/fix-foldstyle-option/types.d.ts)
-   `foldStyle? boolean;`  -> `foldStyle? "markbegin" | "markbeginend" | "manual";` in [react-ace/src/types.ts](https://github.com/bouzidanas/react-ace/blob/fix-foldstyle-option/types.d.ts)

Documentation:
- No need to change documentation

References:
- [Ace Documentation on `foldStyle` option (Session options)](https://github.com/ajaxorg/ace/wiki/Configuring-Ace#session-options)

- Should resolve #1790 (folding now works in my AceEditor components)