### PR TITLE
ace-builds bumped from 1.4.14 to 1.23.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "10.1.0",
       "license": "MIT",
       "dependencies": {
-        "ace-builds": "^1.4.14",
+        "ace-builds": "^1.23.1",
         "diff-match-patch": "^1.0.5",
         "lodash.get": "^4.4.2",
         "lodash.isequal": "^4.5.0",
@@ -2878,9 +2878,9 @@
       }
     },
     "node_modules/ace-builds": {
-      "version": "1.4.14",
-      "resolved": "https://registry.npmjs.org/ace-builds/-/ace-builds-1.4.14.tgz",
-      "integrity": "sha512-NBOQlm9+7RBqRqZwimpgquaLeTJFayqb9UEPtTkpC3TkkwDnlsT/TwsCC0svjt9kEZ6G9mH5AEOHSz6Q/HrzQQ=="
+      "version": "1.23.1",
+      "resolved": "https://registry.npmjs.org/ace-builds/-/ace-builds-1.23.1.tgz",
+      "integrity": "sha512-vmLfsfOOvEiQPri2Vz+76FvUalz/nHB7+X2GqonG7rc2V+WrHvqc4xYowt1+fxHH3aWw/pDF2jqKQrd8JNMmiQ=="
     },
     "node_modules/acorn": {
       "version": "8.8.0",
@@ -14441,9 +14441,9 @@
       }
     },
     "ace-builds": {
-      "version": "1.4.14",
-      "resolved": "https://registry.npmjs.org/ace-builds/-/ace-builds-1.4.14.tgz",
-      "integrity": "sha512-NBOQlm9+7RBqRqZwimpgquaLeTJFayqb9UEPtTkpC3TkkwDnlsT/TwsCC0svjt9kEZ6G9mH5AEOHSz6Q/HrzQQ=="
+      "version": "1.23.1",
+      "resolved": "https://registry.npmjs.org/ace-builds/-/ace-builds-1.23.1.tgz",
+      "integrity": "sha512-vmLfsfOOvEiQPri2Vz+76FvUalz/nHB7+X2GqonG7rc2V+WrHvqc4xYowt1+fxHH3aWw/pDF2jqKQrd8JNMmiQ=="
     },
     "acorn": {
       "version": "8.8.0",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "react"
   ],
   "dependencies": {
-    "ace-builds": "^1.4.14",
+    "ace-builds": "^1.23.1",
     "diff-match-patch": "^1.0.5",
     "lodash.get": "^4.4.2",
     "lodash.isequal": "^4.5.0",

--- a/src/ace.tsx
+++ b/src/ace.tsx
@@ -203,7 +203,7 @@ export default class ReactAce extends React.Component<IAceEditorProps> {
       placeholder
     } = this.props;
 
-    this.editor = ace.edit(this.refEditor);
+    this.editor = ace.edit(this.refEditor) as IAceEditor;
 
     if (onBeforeLoad) {
       onBeforeLoad(ace);

--- a/src/types.ts
+++ b/src/types.ts
@@ -130,7 +130,7 @@ export interface IAnnotation {
 
 interface IRenderer extends Ace.VirtualRenderer {
   placeholderNode?: HTMLDivElement;
-  scroller?: HTMLDivElement;
+  scroller: HTMLDivElement;
 }
 
 export type IAceEditor = Ace.Editor & {


### PR DESCRIPTION
# What's in this PR?

PR bumps ace-builds from 1.4.14 to 1.23.1.

## List the changes you made and your reasons for them.

Due to changes in `Ace.VirtualRenderer` API, it was necessary to make `IRenderer.scroller` mandatory.

Also because of the fact that `ace.edit` returns `Ace.Editor` which doesn't contain `scroller`, it was necessary to downcast it in one place into `IAceEditor`

## References

### Fixes #1547 