### PR TITLE
Add readOnly property to ICommand interface

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -60,6 +60,7 @@ export interface ICommand {
   name: string;
   bindKey: ICommandBindKey;
   exec: string | ICommandExecFunction;
+  readOnly?: boolean;
 }
 export interface IAceOptions {
   [index: string]: any;


### PR DESCRIPTION
# What's in this PR?

It adds the `readOnly?: boolean;` property to the `ICommand` interface.

## List the changes you made and your reasons for them.

The only thing missing was the type. I checked and the commands work correctly.
