### PR TITLE
`this.editor` null check

### DIFF
--- a/src/ace.tsx
+++ b/src/ace.tsx
@@ -460,7 +460,7 @@ export default class ReactAce extends React.Component<IAceEditorProps> {
   }
 
   public onChange(event: any) {
-    if (this.props.onChange && !this.silent) {
+    if (this.editor && this.props.onChange && !this.silent) {
       const value = this.editor.getValue();
       this.props.onChange(value, event);
     }


### PR DESCRIPTION
# What's in this PR?

I ran into a bug where the `onChange` handler is attempted to be called on the unmounted element (because of the debounced `onChange` method). Thus, it throws `Cannot read properties of null (reading 'getValue')`.


## List the changes you made and your reasons for them.

Make sure any changes to code include changes to documentation.

## References

### Fixes #

### Progress on: #