### PR TITLE
Update types.ts to match ace-builds

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -130,7 +130,7 @@ export interface IAnnotation {
 
 interface IRenderer extends Ace.VirtualRenderer {
   placeholderNode?: HTMLDivElement;
-  scroller: HTMLDivElement;
+  scroller: HTMLElement;
 }
 
 export type IAceEditor = Ace.Editor & {


### PR DESCRIPTION
ace-builds defines scroller as an HTMLElement. This change avoids type errors when using IAceEditor as the type of the editor reference returned from onLoad.

# What's in this PR?

A small change to the `react-ace` typings.

## List the changes you made and your reasons for them.

To match `ace-builds`, specifically the `scroller` element defined here: https://github.com/ajaxorg/ace-builds/blob/master/ace.d.ts#L683.