### PR TITLE
bump ace-builds up to 1.36.3 and added their new enableMobileMenu option

### DIFF
--- a/example/index.js
+++ b/example/index.js
@@ -115,6 +115,7 @@ class App extends Component {
       fontSize: 14,
       lineHeight: 19,
       showGutter: true,
+      enableMobileMenu: true,
       showPrintMargin: true,
       highlightActiveLine: true,
       enableSnippets: false,
@@ -254,6 +255,23 @@ class App extends Component {
               </label>
             </p>
           </div>
+            <div className="field">
+            <p className="control">
+              <label className="checkbox">
+                <input
+                  type="checkbox"
+                  checked={this.state.enableMobileMenu}
+                  onChange={e =>{
+                    this.setBoolean(
+                      "enableMobileMenu",
+                      e.target.checked
+                    )
+                  }}
+                />
+                Enable Mobile Menue
+              </label>
+            </p>
+          </div>
           <div className="field">
             <p className="control">
               <label className="checkbox">
@@ -346,6 +364,7 @@ class App extends Component {
             setOptions={{
               useWorker: false,
               enableBasicAutocompletion: this.state.enableBasicAutocompletion,
+              enableMobileMenu: this.state.enableMobileMenu,
               enableLiveAutocompletion: this.state.enableLiveAutocompletion,
               enableSnippets: this.state.enableSnippets,
               showLineNumbers: this.state.showLineNumbers,
@@ -376,6 +395,7 @@ class App extends Component {
   enableBasicAutocompletion: ${this.state.enableBasicAutocompletion},
   enableLiveAutocompletion: ${this.state.enableLiveAutocompletion},
   enableSnippets: ${this.state.enableSnippets},
+  enableMobileMenu: ${this.state.enableMobileMenu},
   showLineNumbers: ${this.state.showLineNumbers},
   tabSize: 2,
   }}/>

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "11.0.0",
       "license": "MIT",
       "dependencies": {
-        "ace-builds": "^1.32.8",
+        "ace-builds": "^1.36.3",
         "diff-match-patch": "^1.0.5",
         "lodash.get": "^4.4.2",
         "lodash.isequal": "^4.5.0",
@@ -3992,9 +3992,10 @@
       }
     },
     "node_modules/ace-builds": {
-      "version": "1.35.0",
-      "resolved": "https://registry.npmjs.org/ace-builds/-/ace-builds-1.35.0.tgz",
-      "integrity": "sha512-bwDKqjqNccC/MSujqnYTeAS5dIR8UmGLP0R90mvsJY0FRC8NUWBSTfj34+EIzo2NWc/gV8IZTqv4fXaiZJpCtA=="
+      "version": "1.36.3",
+      "resolved": "https://registry.npmjs.org/ace-builds/-/ace-builds-1.36.3.tgz",
+      "integrity": "sha512-YcdwV2IIaJSfjkWAR1NEYN5IxBiXefTgwXsJ//UlaFrjXDX5hQpvPFvEePHz2ZBUfvO54RjHeRUQGX8MS5HaMQ==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/acorn": {
       "version": "8.12.0",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "react"
   ],
   "dependencies": {
-    "ace-builds": "^1.32.8",
+    "ace-builds": "^1.36.3",
     "diff-match-patch": "^1.0.5",
     "lodash.get": "^4.4.2",
     "lodash.isequal": "^4.5.0",

--- a/src/ace.tsx
+++ b/src/ace.tsx
@@ -47,6 +47,7 @@ export interface IAceEditorProps {
   debounceChangePeriod?: number;
   enableBasicAutocompletion?: boolean | string[];
   enableLiveAutocompletion?: boolean | string[];
+  enableMobileMenu?: boolean;
   tabSize?: number;
   value?: string;
   placeholder?: string;


### PR DESCRIPTION
# What's in this PR?
use new ace-builds version
added the "enableMobileMenu" option

## List the changes you made and your reasons for them.
use new ace-builds version
added the "enableMobileMenu" option

Make sure any changes to code include changes to documentation.

## References
https://github.com/ajaxorg/ace/pull/5580

### Fixes #

### Progress on: #