### PR TITLE
Fix handling of a null or absent "markers" property

### DIFF
--- a/src/ace.tsx
+++ b/src/ace.tsx
@@ -421,11 +421,10 @@ export default class ReactAce extends React.Component<IAceEditorProps> {
     if (valueChanged || !isEqual(nextProps.annotations, oldProps.annotations)) {
       this.editor.getSession().setAnnotations(nextProps.annotations || []);
     }
-    if (
-      !isEqual(nextProps.markers, oldProps.markers) &&
-      Array.isArray(nextProps.markers)
-    ) {
-      this.handleMarkers(nextProps.markers);
+    const oldMarkers = oldProps.markers || [];
+    const nextMarkers = nextProps.markers || [];
+    if (!isEqual(oldMarkers, nextMarkers)) {
+      this.handleMarkers(nextMarkers);
     }
 
     // this doesn't look like it works at all....


### PR DESCRIPTION
Fix handling of a null or absent "markers" property.

Steps to reproduce this issue:
* Provide some markers (i.e. non-empty array) to the AceEditor component
* In a later rendering, provide instead a null or absent "markers" property

Expected result:
* The markers disappear

Actual result:
* The markers from the previous rendering are still present.

Workaround:
* Provide explicitly an empty array as "markers" property. 

This PR ensures that absent or null markers are always treated the exact same way as an empty array.